### PR TITLE
QGM query rewrite exercise

### DIFF
--- a/doc/user/content/known-limitations.md
+++ b/doc/user/content/known-limitations.md
@@ -31,9 +31,6 @@ us know on the linked-to GitHub issue.
 ### Common table expressions (CTEs)
 
 - CTEs only support `SELECT` queries. {{% gh 4867 %}}
-- Materialize inlines the CTE where it's referenced, which could cause
-  unexpected performance characteristics for especially complex expressions. {{%
-  gh 4867 %}}
 - `WITH RECURSIVE` CTEs are not available yet. {{% gh 2516 %}}
 
 ### Joins

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -195,6 +195,8 @@ boundary don't silently merge their release notes into the wrong place.
   This bug could cause incorrect results in queries that combined `RIGHT` and
   `FULL` [joins](/sql/join) with comma-separated `FROM` items.
 
+- Materialize no longer inlines the CTE where it's referenced {{% gh 4867 %}}.
+
 {{% version-header v0.12.0 %}}
 
 - Optionally emit the message partition, offset, and timestamp in [Kafka

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3320,6 +3320,10 @@ where
                 }
                 explanation.to_string()
             }
+            ExplainStage::QueryGraph => {
+                let model = sql::query_model::Model::from(raw_plan);
+                sql::query_model::dot::DotGenerator::new().generate(&model, "")?
+            }
             ExplainStage::DecorrelatedPlan => {
                 let decorrelated_plan = OptimizedMirRelationExpr::declare_optimized(decorrelate(
                     &mut timings,

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3324,6 +3324,11 @@ where
                 let model = sql::query_model::Model::from(raw_plan);
                 sql::query_model::dot::DotGenerator::new().generate(&model, "")?
             }
+            ExplainStage::OptimizedQueryGraph => {
+                let mut model = sql::query_model::Model::from(raw_plan);
+                sql::query_model::rewrite_engine::rewrite_model(&mut model);
+                sql::query_model::dot::DotGenerator::new().generate(&model, "")?
+            }
             ExplainStage::DecorrelatedPlan => {
                 let decorrelated_plan = OptimizedMirRelationExpr::declare_optimized(decorrelate(
                     &mut timings,

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -38,8 +38,8 @@ pub use relation::func::{AggregateFunc, TableFunc};
 pub use relation::func::{AnalyzedRegex, CaptureGroupDesc};
 pub use relation::join_input_mapper::JoinInputMapper;
 pub use relation::{
-    compare_columns, AggregateExpr, ColumnOrder, JoinImplementation, MirRelationExpr,
-    RowSetFinishing, RECURSION_LIMIT,
+    compare_columns, find_unique_keys_in_constant, find_unique_keys_in_reduce, AggregateExpr,
+    ColumnOrder, JoinImplementation, MirRelationExpr, RowSetFinishing, RECURSION_LIMIT,
 };
 pub use scalar::func::{self, BinaryFunc, NullaryFunc, UnaryFunc, VariadicFunc};
 pub use scalar::{like_pattern, EvalError, MirScalarExpr};

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -588,7 +588,9 @@ where
     })
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzEnumReflect)]
+#[derive(
+    Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzEnumReflect,
+)]
 pub enum AggregateFunc {
     MaxNumeric,
     MaxInt16,

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1851,7 +1851,9 @@ impl CheckedRecursion for MirRelationExprVisitor {
 }
 
 /// Specification for an ordering by a column.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, MzStructReflect)]
+#[derive(
+    Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, MzStructReflect,
+)]
 pub struct ColumnOrder {
     /// The column index.
     pub column: usize,

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1558,6 +1558,8 @@ impl_display_t!(Assignment);
 pub enum ExplainStage {
     /// The sql::HirRelationExpr after parsing
     RawPlan,
+    /// Query Graph
+    QueryGraph,
     /// The expr::MirRelationExpr after decorrelation
     DecorrelatedPlan,
     /// The expr::MirRelationExpr after optimization
@@ -1570,6 +1572,7 @@ impl AstDisplay for ExplainStage {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             ExplainStage::RawPlan => f.write_str("RAW PLAN"),
+            ExplainStage::QueryGraph => f.write_str("QUERY GRAPH"),
             ExplainStage::DecorrelatedPlan => f.write_str("DECORRELATED PLAN"),
             ExplainStage::OptimizedPlan => f.write_str("OPTIMIZED PLAN"),
             ExplainStage::PhysicalPlan => f.write_str("PHYSICAL PLAN"),

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1560,6 +1560,8 @@ pub enum ExplainStage {
     RawPlan,
     /// Query Graph
     QueryGraph,
+    /// Optimized Query Graph
+    OptimizedQueryGraph,
     /// The expr::MirRelationExpr after decorrelation
     DecorrelatedPlan,
     /// The expr::MirRelationExpr after optimization
@@ -1572,6 +1574,7 @@ impl AstDisplay for ExplainStage {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             ExplainStage::RawPlan => f.write_str("RAW PLAN"),
+            ExplainStage::OptimizedQueryGraph => f.write_str("OPTIMIZED QUERY GRAPH"),
             ExplainStage::QueryGraph => f.write_str("QUERY GRAPH"),
             ExplainStage::DecorrelatedPlan => f.write_str("DECORRELATED PLAN"),
             ExplainStage::OptimizedPlan => f.write_str("OPTIMIZED PLAN"),

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -114,6 +114,7 @@ Format
 Forward
 From
 Full
+Graph
 Group
 Groups
 Gzip
@@ -200,6 +201,7 @@ Primary
 Protobuf
 Publication
 Pubnub
+Query
 Range
 Raw
 Read

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4306,8 +4306,13 @@ impl<'a> Parser<'a> {
                 ExplainStage::DecorrelatedPlan
             }
             Some(OPTIMIZED) => {
-                self.expect_keywords(&[PLAN, FOR])?;
-                ExplainStage::OptimizedPlan
+                if self.parse_keyword(QUERY) {
+                    self.expect_keywords(&[GRAPH, FOR])?;
+                    ExplainStage::OptimizedQueryGraph
+                } else {
+                    self.expect_keywords(&[PLAN, FOR])?;
+                    ExplainStage::OptimizedPlan
+                }
             }
             Some(PLAN) => {
                 self.expect_keyword(FOR)?;

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4285,31 +4285,41 @@ impl<'a> Parser<'a> {
         }
 
         // (RAW | DECORRELATED | OPTIMIZED | PHYSICAL)? PLAN
-        let stage =
-            match self.parse_one_of_keywords(&[RAW, DECORRELATED, OPTIMIZED, PHYSICAL, PLAN]) {
-                Some(RAW) => {
-                    self.expect_keywords(&[PLAN, FOR])?;
-                    ExplainStage::RawPlan
-                }
-                Some(DECORRELATED) => {
-                    self.expect_keywords(&[PLAN, FOR])?;
-                    ExplainStage::DecorrelatedPlan
-                }
-                Some(OPTIMIZED) => {
-                    self.expect_keywords(&[PLAN, FOR])?;
-                    ExplainStage::OptimizedPlan
-                }
-                Some(PLAN) => {
-                    self.expect_keyword(FOR)?;
-                    ExplainStage::OptimizedPlan
-                }
-                Some(PHYSICAL) => {
-                    self.expect_keywords(&[PLAN, FOR])?;
-                    ExplainStage::PhysicalPlan
-                }
-                None => ExplainStage::OptimizedPlan,
-                _ => unreachable!(),
-            };
+        let stage = match self.parse_one_of_keywords(&[
+            RAW,
+            DECORRELATED,
+            OPTIMIZED,
+            PHYSICAL,
+            PLAN,
+            QUERY,
+        ]) {
+            Some(RAW) => {
+                self.expect_keywords(&[PLAN, FOR])?;
+                ExplainStage::RawPlan
+            }
+            Some(QUERY) => {
+                self.expect_keywords(&[GRAPH, FOR])?;
+                ExplainStage::QueryGraph
+            }
+            Some(DECORRELATED) => {
+                self.expect_keywords(&[PLAN, FOR])?;
+                ExplainStage::DecorrelatedPlan
+            }
+            Some(OPTIMIZED) => {
+                self.expect_keywords(&[PLAN, FOR])?;
+                ExplainStage::OptimizedPlan
+            }
+            Some(PLAN) => {
+                self.expect_keyword(FOR)?;
+                ExplainStage::OptimizedPlan
+            }
+            Some(PHYSICAL) => {
+                self.expect_keywords(&[PLAN, FOR])?;
+                ExplainStage::PhysicalPlan
+            }
+            None => ExplainStage::OptimizedPlan,
+            _ => unreachable!(),
+        };
 
         // VIEW view_name | query
         let explainee = if self.parse_keyword(VIEW) {

--- a/src/sql/src/plan/explain.rs
+++ b/src/sql/src/plan/explain.rs
@@ -22,7 +22,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
 use expr::explain::Indices;
-use expr::{ExprHumanizer, Id, RowSetFinishing};
+use expr::{ExprHumanizer, Id, LocalId, RowSetFinishing};
 use ore::collections::CollectionExt;
 use ore::id_gen::IdGen;
 use ore::str::{bracketed, separated};
@@ -45,6 +45,10 @@ pub struct Explanation<'a> {
     finishing: Option<RowSetFinishing>,
     /// Records the chain ID that was assigned to each expression.
     expr_chains: HashMap<*const HirRelationExpr, u64>,
+    /// Records the chain ID that was assigned to each let.
+    local_id_chains: HashMap<LocalId, u64>,
+    /// Records the local ID that corresponds to a chain ID, if any.
+    chain_local_ids: HashMap<u64, LocalId>,
     /// The ID of the current chain. Incremented while constructing the
     /// `Explanation`.
     chain: u64,
@@ -71,6 +75,9 @@ impl<'a> fmt::Display for Explanation<'a> {
                     writeln!(f)?;
                 }
                 write!(f, "%{} =", node.chain)?;
+                if let Some(local_id) = self.chain_local_ids.get(&node.chain) {
+                    write!(f, " Let {} =", local_id)?;
+                }
                 writeln!(f)?;
             }
             prev_chain = node.chain;
@@ -137,19 +144,25 @@ impl<'a> Explanation<'a> {
                 | DeclareKeys { input, .. }
                 | Threshold { input, .. } => walk(input, explanation, id_gen),
                 // For join and union, each input needs to go in its own chain.
-                Join { left, right, .. } => {
-                    walk(left, explanation, id_gen);
-                    explanation.chain = id_gen.allocate_id();
-                    walk(right, explanation, id_gen);
-                    explanation.chain = id_gen.allocate_id();
-                }
+                Join { left, right, .. } => walk_many(
+                    std::iter::once(&**left).chain(std::iter::once(&**right)),
+                    explanation,
+                    id_gen,
+                ),
                 Union { base, inputs, .. } => {
-                    walk(base, explanation, id_gen);
+                    walk_many(std::iter::once(&**base).chain(inputs), explanation, id_gen)
+                }
+                Let { id, body, value } => {
+                    // Similarly the definition of a let goes in its own chain.
+                    walk(value, explanation, id_gen);
                     explanation.chain = id_gen.allocate_id();
-                    for input in inputs {
-                        walk(input, explanation, id_gen);
-                        explanation.chain = id_gen.allocate_id();
-                    }
+
+                    // Keep track of the chain ID <-> local ID correspondence.
+                    let value_chain = explanation.expr_chain(value);
+                    explanation.local_id_chains.insert(*id, value_chain);
+                    explanation.chain_local_ids.insert(value_chain, *id);
+
+                    walk(body, explanation, id_gen);
                 }
             }
 
@@ -158,6 +171,7 @@ impl<'a> Explanation<'a> {
             match expr {
                 Constant { .. }
                 | Get { .. }
+                | Let { .. }
                 | Project { .. }
                 | Distinct { .. }
                 | Negate { .. }
@@ -205,11 +219,34 @@ impl<'a> Explanation<'a> {
                 .insert(expr as *const HirRelationExpr, explanation.chain);
         }
 
+        fn walk_many<'a, E>(exprs: E, explanation: &mut Explanation<'a>, id_gen: &mut IdGen)
+        where
+            E: IntoIterator<Item = &'a HirRelationExpr>,
+        {
+            for expr in exprs {
+                // Elide chains that would consist only a of single Get node.
+                if let HirRelationExpr::Get {
+                    id: Id::Local(id), ..
+                } = expr
+                {
+                    explanation.expr_chains.insert(
+                        expr as *const HirRelationExpr,
+                        explanation.local_id_chains[id],
+                    );
+                } else {
+                    walk(expr, explanation, id_gen);
+                    explanation.chain = id_gen.allocate_id();
+                }
+            }
+        }
+
         let mut explanation = Explanation {
             expr_humanizer,
             nodes: vec![],
             finishing: None,
             expr_chains: HashMap::new(),
+            local_id_chains: HashMap::new(),
+            chain_local_ids: HashMap::new(),
             chain: id_gen.allocate_id(),
         };
         walk(expr, &mut explanation, id_gen);
@@ -247,6 +284,8 @@ impl<'a> Explanation<'a> {
         use HirRelationExpr::*;
 
         match node.expr {
+            // Lets are annotated on the chain ID that they correspond to.
+            Let { .. } => (),
             Constant { rows, .. } => {
                 write!(f, "| Constant")?;
                 for row in rows {
@@ -255,9 +294,14 @@ impl<'a> Explanation<'a> {
                 writeln!(f)?;
             }
             Get { id, .. } => match id {
-                Id::Local(_) => {
-                    unreachable!("SQL expressions do not support Lets yet")
-                }
+                Id::Local(local_id) => writeln!(
+                    f,
+                    "| Get %{} ({})",
+                    self.local_id_chains
+                        .get(local_id)
+                        .map_or_else(|| "?".to_owned(), |i| i.to_string()),
+                    local_id,
+                )?,
                 Id::LocalBareSource => writeln!(f, "| Get Local Bare Source")?,
                 Id::Global(id) => writeln!(
                     f,

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -37,8 +37,6 @@ use super::Explanation;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 /// Just like MirRelationExpr, except where otherwise noted below.
-///
-/// - There is no equivalent to `MirRelationExpr::Let`.
 pub enum HirRelationExpr {
     Constant {
         rows: Vec<Row>,
@@ -47,6 +45,15 @@ pub enum HirRelationExpr {
     Get {
         id: expr::Id,
         typ: RelationType,
+    },
+    /// CTE
+    Let {
+        /// The identifier to be used in `Get` variants to retrieve `value`.
+        id: expr::LocalId,
+        /// The collection to be bound to `name`.
+        value: Box<HirRelationExpr>,
+        /// The result of the `Let`, evaluated with `name` bound to `value`.
+        body: Box<HirRelationExpr>,
     },
     Project {
         input: Box<HirRelationExpr>,
@@ -689,6 +696,7 @@ impl HirRelationExpr {
         stack::maybe_grow(|| match self {
             HirRelationExpr::Constant { typ, .. } => typ.clone(),
             HirRelationExpr::Get { typ, .. } => typ.clone(),
+            HirRelationExpr::Let { body, .. } => body.typ(outers, params),
             HirRelationExpr::Project { input, outputs } => {
                 let input_typ = input.typ(outers, params);
                 RelationType::new(
@@ -774,6 +782,7 @@ impl HirRelationExpr {
         match self {
             HirRelationExpr::Constant { typ, .. } => typ.column_types.len(),
             HirRelationExpr::Get { typ, .. } => typ.column_types.len(),
+            HirRelationExpr::Let { body, .. } => body.arity(),
             HirRelationExpr::Project { outputs, .. } => outputs.len(),
             HirRelationExpr::Map { input, scalars } => input.arity() + scalars.len(),
             HirRelationExpr::CallTable { func, .. } => func.output_arity(),
@@ -985,6 +994,10 @@ impl HirRelationExpr {
             HirRelationExpr::Constant { .. }
             | HirRelationExpr::Get { .. }
             | HirRelationExpr::CallTable { .. } => (),
+            HirRelationExpr::Let { body, value, .. } => {
+                f(value);
+                f(body);
+            }
             HirRelationExpr::Project { input, .. } => {
                 f(input);
             }
@@ -1041,6 +1054,10 @@ impl HirRelationExpr {
             HirRelationExpr::Constant { .. }
             | HirRelationExpr::Get { .. }
             | HirRelationExpr::CallTable { .. } => (),
+            HirRelationExpr::Let { body, value, .. } => {
+                f(value);
+                f(body);
+            }
             HirRelationExpr::Project { input, .. } => {
                 f(input);
             }
@@ -1091,6 +1108,10 @@ impl HirRelationExpr {
         F: FnMut(usize, &ColumnRef),
     {
         match self {
+            HirRelationExpr::Let { body, value, .. } => {
+                value.visit_columns(depth, f);
+                body.visit_columns(depth, f);
+            }
             HirRelationExpr::Join {
                 on, left, right, ..
             } => {
@@ -1148,6 +1169,10 @@ impl HirRelationExpr {
         F: FnMut(usize, &mut ColumnRef),
     {
         match self {
+            HirRelationExpr::Let { body, value, .. } => {
+                value.visit_columns_mut(depth, f);
+                body.visit_columns_mut(depth, f);
+            }
             HirRelationExpr::Join {
                 on, left, right, ..
             } => {
@@ -1203,6 +1228,10 @@ impl HirRelationExpr {
     /// corresponding datum from `params`.
     pub fn bind_parameters(&mut self, params: &Params) -> Result<(), anyhow::Error> {
         match self {
+            HirRelationExpr::Let { body, value, .. } => {
+                value.bind_parameters(params)?;
+                body.bind_parameters(params)
+            }
             HirRelationExpr::Join {
                 on, left, right, ..
             } => {
@@ -1255,6 +1284,10 @@ impl HirRelationExpr {
     /// See the documentation for [`HirScalarExpr::splice_parameters`].
     pub fn splice_parameters(&mut self, params: &[HirScalarExpr], depth: usize) {
         match self {
+            HirRelationExpr::Let { body, value, .. } => {
+                value.splice_parameters(params, depth);
+                body.splice_parameters(params, depth);
+            }
             HirRelationExpr::Join {
                 on, left, right, ..
             } => {

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -314,7 +314,7 @@ impl ScalarWindowExpr {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Scalar Window functions
 pub enum ScalarWindowFunc {
     RowNumber,

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -320,6 +320,14 @@ pub enum ScalarWindowFunc {
     RowNumber,
 }
 
+impl fmt::Display for ScalarWindowFunc {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ScalarWindowFunc::RowNumber => f.write_str("row_number"),
+        }
+    }
+}
+
 /// A `CoercibleScalarExpr` is a [`HirScalarExpr`] whose type is not fully
 /// determined. Several SQL expressions can be freely coerced based upon where
 /// in the expression tree they appear. For example, the string literal '42'

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -112,6 +112,21 @@ impl ColumnMap {
     }
 }
 
+/// Map with the CTEs currently in scope.
+type CteMap = HashMap<expr::LocalId, CteDesc>;
+
+/// Information about needed when finding a reference to a CTE in scope.
+struct CteDesc {
+    /// The new ID assigned to the lowered vesion of the CTE, which may not match
+    /// the ID of the input CTE.
+    new_id: expr::LocalId,
+    /// The relation type of the CTE including the columns from the outer
+    /// context at the beginning.
+    relation_type: RelationType,
+    /// The outer relation the CTE was applied to.
+    outer_relation: expr::MirRelationExpr,
+}
+
 impl HirRelationExpr {
     /// Rewrite `self` into a `expr::MirRelationExpr`.
     /// This requires rewriting all correlated subqueries (nested `HirRelationExpr`s) into flat queries
@@ -133,10 +148,17 @@ impl HirRelationExpr {
                 let mut id_gen = ore::id_gen::IdGen::default();
                 transform_expr::split_subquery_predicates(&mut other);
                 transform_expr::try_simplify_quantified_comparisons(&mut other);
-                expr::MirRelationExpr::constant(vec![vec![]], RelationType::new(vec![]))
-                    .let_in(&mut id_gen, |id_gen, get_outer| {
-                        other.applied_to(id_gen, get_outer, &ColumnMap::empty())
-                    })
+                expr::MirRelationExpr::constant(vec![vec![]], RelationType::new(vec![])).let_in(
+                    &mut id_gen,
+                    |id_gen, get_outer| {
+                        other.applied_to(
+                            id_gen,
+                            get_outer,
+                            &ColumnMap::empty(),
+                            &mut HashMap::new(),
+                        )
+                    },
+                )
             }
         }
     }
@@ -158,6 +180,7 @@ impl HirRelationExpr {
         id_gen: &mut ore::id_gen::IdGen,
         get_outer: expr::MirRelationExpr,
         col_map: &ColumnMap,
+        cte_map: &mut CteMap,
     ) -> expr::MirRelationExpr {
         maybe_grow(|| {
             use self::HirRelationExpr::*;
@@ -178,14 +201,86 @@ impl HirRelationExpr {
                         typ,
                     })
                 }
-                Get { id, typ } => {
-                    // Get statements are only to external sources, and are not correlated with `get_outer`.
-                    get_outer.product(SR::Get { id, typ })
+                Get { id, typ } => match id {
+                    expr::Id::Local(local_id) => {
+                        let cte_desc = cte_map.get(&local_id).unwrap();
+                        let get_cte = SR::Get {
+                            id: expr::Id::Local(cte_desc.new_id.clone()),
+                            typ: cte_desc.relation_type.clone(),
+                        };
+                        if get_outer == cte_desc.outer_relation {
+                            // If the CTE was applied to the same exact relation, we can safely
+                            // return a `Get` relation.
+                            get_cte
+                        } else {
+                            // Otherwise, the new outer relation may contain more columns from some
+                            // intermediate scope placed between the definition of the CTE and the
+                            // reference of the CTE. In that case, `get_outer` is guaranteed to
+                            // contain the columns of the outer relation the CTE was applied to at
+                            // its prefix. Since, we must return a relation containing `get_outer`'s
+                            // column at the beginning, we must build a join between `get_outer` and
+                            // `get_cte` on their common columns.
+                            let mut equivalences = Vec::new();
+                            let oa = get_outer.arity();
+                            let cte_outer_columns = cte_desc.relation_type.arity() - typ.arity();
+                            for position in 0..cte_outer_columns {
+                                equivalences.push(vec![
+                                    expr::MirScalarExpr::column(position),
+                                    expr::MirScalarExpr::column(oa + position),
+                                ]);
+                            }
+
+                            // Project out the second copy of the common between `get_outer` and
+                            // `cte_desc.outer_relation`.
+                            let projection = (0..oa)
+                                .chain(oa + cte_outer_columns..oa + cte_outer_columns + typ.arity())
+                                .collect_vec();
+                            SR::join_scalars(vec![get_outer, get_cte], equivalences)
+                                .project(projection)
+                        }
+                    }
+
+                    _ => get_outer.product(SR::Get { id, typ }),
+                },
+                Let { id, value, body } => {
+                    let value = value.applied_to(id_gen, get_outer.clone(), col_map, cte_map);
+                    value.let_in(id_gen, |id_gen, get_value| {
+                        let (new_id, typ) = if let expr::MirRelationExpr::Get {
+                            id: expr::Id::Local(id),
+                            typ,
+                            ..
+                        } = get_value
+                        {
+                            (id, typ)
+                        } else {
+                            panic!(
+                                "get_value: expected a MirRelationExpr::Get, found {:?}",
+                                get_value
+                            );
+                        };
+                        // Add the information about the CTE to the map and remove it when
+                        // it goes out of scope.
+                        let old_value = cte_map.insert(
+                            id.clone(),
+                            CteDesc {
+                                new_id,
+                                relation_type: typ,
+                                outer_relation: get_outer.clone(),
+                            },
+                        );
+                        let body = body.applied_to(id_gen, get_outer, col_map, cte_map);
+                        if let Some(old_value) = old_value {
+                            cte_map.insert(id, old_value);
+                        } else {
+                            cte_map.remove(&id);
+                        }
+                        body
+                    })
                 }
                 Project { input, outputs } => {
                     // Projections should be applied to the decorrelated `inner`, and to its columns,
                     // which means rebasing `outputs` to start `get_outer.arity()` columns later.
-                    let input = input.applied_to(id_gen, get_outer.clone(), col_map);
+                    let input = input.applied_to(id_gen, get_outer.clone(), col_map, cte_map);
                     let outputs = (0..get_outer.arity())
                         .chain(outputs.into_iter().map(|i| get_outer.arity() + i))
                         .collect::<Vec<_>>();
@@ -193,7 +288,7 @@ impl HirRelationExpr {
                 }
                 Map { input, mut scalars } => {
                     // Scalar expressions may contain correlated subqueries. We must be cautious!
-                    let mut input = input.applied_to(id_gen, get_outer, col_map);
+                    let mut input = input.applied_to(id_gen, get_outer, col_map, cte_map);
 
                     // Lower subqueries in maximally sized batches, such as no subquery in the current
                     // batch depends on columns from the same batch.
@@ -217,8 +312,9 @@ impl HirRelationExpr {
                             .unwrap_or(scalars.len());
 
                         let scalars = scalars.drain(0..end_idx).collect_vec();
-                        let (with_subqueries, subquery_map) =
-                            HirScalarExpr::lower_subqueries(&scalars, id_gen, col_map, input);
+                        let (with_subqueries, subquery_map) = HirScalarExpr::lower_subqueries(
+                            &scalars, id_gen, col_map, cte_map, input,
+                        );
                         input = with_subqueries;
 
                         // We will proceed sequentially through the scalar expressions, for each transforming
@@ -234,6 +330,7 @@ impl HirRelationExpr {
                             let scalar = scalar.applied_to(
                                 id_gen,
                                 col_map,
+                                cte_map,
                                 &mut input,
                                 &Some(&subquery_map),
                             );
@@ -258,7 +355,7 @@ impl HirRelationExpr {
 
                     let exprs = exprs
                         .into_iter()
-                        .map(|e| e.applied_to(id_gen, col_map, &mut input, &None))
+                        .map(|e| e.applied_to(id_gen, col_map, cte_map, &mut input, &None))
                         .collect::<Vec<_>>();
 
                     let new_arity = input.arity();
@@ -278,10 +375,11 @@ impl HirRelationExpr {
                     // Filter expressions may contain correlated subqueries.
                     // We extend `get_outer` with sufficient values to determine the value of the predicate,
                     // then filter the results, then strip off any columns that were added for this purpose.
-                    let mut input = input.applied_to(id_gen, get_outer, col_map);
+                    let mut input = input.applied_to(id_gen, get_outer, col_map, cte_map);
                     for predicate in predicates {
                         let old_arity = input.arity();
-                        let predicate = predicate.applied_to(id_gen, col_map, &mut input, &None);
+                        let predicate =
+                            predicate.applied_to(id_gen, col_map, cte_map, &mut input, &None);
                         let new_arity = input.arity();
                         input = input.filter(vec![predicate]);
                         if old_arity != new_arity {
@@ -308,23 +406,24 @@ impl HirRelationExpr {
 
                     assert!(kind.can_be_correlated());
 
-                    let left = left.applied_to(id_gen, get_outer, col_map);
+                    let left = left.applied_to(id_gen, get_outer, col_map, cte_map);
                     left.let_in(id_gen, |id_gen, get_left| {
                         let apply_requires_distinct_outer = false;
                         let mut join = branch(
                             id_gen,
                             get_left.clone(),
                             col_map,
+                            cte_map,
                             *right,
                             apply_requires_distinct_outer,
-                            |id_gen, right, get_left, col_map| {
-                                right.applied_to(id_gen, get_left, col_map)
+                            |id_gen, right, get_left, col_map, cte_map| {
+                                right.applied_to(id_gen, get_left, col_map, cte_map)
                             },
                         );
 
                         // Plan the `on` predicate.
                         let old_arity = join.arity();
-                        let on = on.applied_to(id_gen, col_map, &mut join, &None);
+                        let on = on.applied_to(id_gen, col_map, cte_map, &mut join, &None);
                         join = join.filter(vec![on]);
                         let new_arity = join.arity();
                         if old_arity != new_arity {
@@ -365,12 +464,13 @@ impl HirRelationExpr {
                     // against the records present in the left and right (decorrelated) inputs,
                     // depending on the type of join.
                     let oa = get_outer.arity();
-                    let left = left.applied_to(id_gen, get_outer.clone(), col_map);
+                    let left = left.applied_to(id_gen, get_outer.clone(), col_map, cte_map);
                     let lt = left.typ();
                     let la = left.arity() - oa;
                     left.let_in(id_gen, |id_gen, get_left| {
                         let right_col_map = col_map.enter_scope(0);
-                        let right = right.applied_to(id_gen, get_outer.clone(), &right_col_map);
+                        let right =
+                            right.applied_to(id_gen, get_outer.clone(), &right_col_map, cte_map);
                         let rt = right.typ();
                         let ra = right.arity() - oa;
                         right.let_in(id_gen, |id_gen, get_right| {
@@ -385,7 +485,7 @@ impl HirRelationExpr {
                                     .collect(),
                             );
                             let old_arity = product.arity();
-                            let on = on.applied_to(id_gen, col_map, &mut product, &None);
+                            let on = on.applied_to(id_gen, col_map, cte_map, &mut product, &None);
 
                             // Attempt an efficient equijoin implementation, in which outer joins are
                             // more efficiently rendered than in general. This can return `None` if
@@ -461,10 +561,17 @@ impl HirRelationExpr {
                 Union { base, inputs } => {
                     // Union is uncomplicated.
                     SR::Union {
-                        base: Box::new(base.applied_to(id_gen, get_outer.clone(), col_map)),
+                        base: Box::new(base.applied_to(
+                            id_gen,
+                            get_outer.clone(),
+                            col_map,
+                            cte_map,
+                        )),
                         inputs: inputs
                             .into_iter()
-                            .map(|input| input.applied_to(id_gen, get_outer.clone(), col_map))
+                            .map(|input| {
+                                input.applied_to(id_gen, get_outer.clone(), col_map, cte_map)
+                            })
                             .collect(),
                     }
                 }
@@ -477,13 +584,13 @@ impl HirRelationExpr {
                     // Reduce may contain expressions with correlated subqueries.
                     // In addition, here an empty reduction key signifies that we need to supply default values
                     // in the case that there are no results (as in a SQL aggregation without an explicit GROUP BY).
-                    let mut input = input.applied_to(id_gen, get_outer.clone(), col_map);
+                    let mut input = input.applied_to(id_gen, get_outer.clone(), col_map, cte_map);
                     let applied_group_key = (0..get_outer.arity())
                         .chain(group_key.iter().map(|i| get_outer.arity() + i))
                         .collect();
                     let applied_aggregates = aggregates
                         .into_iter()
-                        .map(|aggregate| aggregate.applied_to(id_gen, col_map, &mut input))
+                        .map(|aggregate| aggregate.applied_to(id_gen, col_map, cte_map, &mut input))
                         .collect::<Vec<_>>();
                     let input_type = input.typ();
                     let default = applied_aggregates
@@ -507,7 +614,9 @@ impl HirRelationExpr {
                 }
                 Distinct { input } => {
                     // Distinct is uncomplicated.
-                    input.applied_to(id_gen, get_outer, col_map).distinct()
+                    input
+                        .applied_to(id_gen, get_outer, col_map, cte_map)
+                        .distinct()
                 }
                 TopK {
                     input,
@@ -517,7 +626,7 @@ impl HirRelationExpr {
                     offset,
                 } => {
                     // TopK is uncomplicated, except that we must group by the columns of `get_outer` as well.
-                    let input = input.applied_to(id_gen, get_outer.clone(), col_map);
+                    let input = input.applied_to(id_gen, get_outer.clone(), col_map, cte_map);
                     let applied_group_key = (0..get_outer.arity())
                         .chain(group_key.iter().map(|i| get_outer.arity() + i))
                         .collect();
@@ -532,14 +641,18 @@ impl HirRelationExpr {
                 }
                 Negate { input } => {
                     // Negate is uncomplicated.
-                    input.applied_to(id_gen, get_outer, col_map).negate()
+                    input
+                        .applied_to(id_gen, get_outer, col_map, cte_map)
+                        .negate()
                 }
                 Threshold { input } => {
                     // Threshold is uncomplicated.
-                    input.applied_to(id_gen, get_outer, col_map).threshold()
+                    input
+                        .applied_to(id_gen, get_outer, col_map, cte_map)
+                        .threshold()
                 }
                 DeclareKeys { input, keys } => input
-                    .applied_to(id_gen, get_outer, col_map)
+                    .applied_to(id_gen, get_outer, col_map, cte_map)
                     .declare_keys(keys),
             }
         })
@@ -561,6 +674,7 @@ impl HirScalarExpr {
         self,
         id_gen: &mut ore::id_gen::IdGen,
         col_map: &ColumnMap,
+        cte_map: &mut CteMap,
         inner: &mut expr::MirRelationExpr,
         subquery_map: &Option<&HashMap<HirScalarExpr, usize>>,
     ) -> expr::MirScalarExpr {
@@ -581,18 +695,30 @@ impl HirScalarExpr {
                 CallNullary(func) => SS::CallNullary(func),
                 CallUnary { func, expr } => SS::CallUnary {
                     func,
-                    expr: Box::new(expr.applied_to(id_gen, col_map, inner, subquery_map)),
+                    expr: Box::new(expr.applied_to(id_gen, col_map, cte_map, inner, subquery_map)),
                 },
                 CallBinary { func, expr1, expr2 } => SS::CallBinary {
                     func,
-                    expr1: Box::new(expr1.applied_to(id_gen, col_map, inner, subquery_map)),
-                    expr2: Box::new(expr2.applied_to(id_gen, col_map, inner, subquery_map)),
+                    expr1: Box::new(expr1.applied_to(
+                        id_gen,
+                        col_map,
+                        cte_map,
+                        inner,
+                        subquery_map,
+                    )),
+                    expr2: Box::new(expr2.applied_to(
+                        id_gen,
+                        col_map,
+                        cte_map,
+                        inner,
+                        subquery_map,
+                    )),
                 },
                 CallVariadic { func, exprs } => SS::CallVariadic {
                     func,
                     exprs: exprs
                         .into_iter()
-                        .map(|expr| expr.applied_to(id_gen, col_map, inner, subquery_map))
+                        .map(|expr| expr.applied_to(id_gen, col_map, cte_map, inner, subquery_map))
                         .collect::<Vec<_>>(),
                 },
                 If { cond, then, els } => {
@@ -617,7 +743,7 @@ impl HirScalarExpr {
                     // and we would benefit from not introducing the complexity.
 
                     let inner_arity = inner.arity();
-                    let cond_expr = cond.applied_to(id_gen, col_map, inner, subquery_map);
+                    let cond_expr = cond.applied_to(id_gen, col_map, cte_map, inner, subquery_map);
 
                     // Defensive copies, in case we mangle these in decorrelation.
                     let inner_clone = inner.clone();
@@ -625,8 +751,8 @@ impl HirScalarExpr {
                     let else_clone = els.clone();
 
                     let cond_arity = inner.arity();
-                    let then_expr = then.applied_to(id_gen, col_map, inner, subquery_map);
-                    let else_expr = els.applied_to(id_gen, col_map, inner, subquery_map);
+                    let then_expr = then.applied_to(id_gen, col_map, cte_map, inner, subquery_map);
+                    let else_expr = els.applied_to(id_gen, col_map, cte_map, inner, subquery_map);
 
                     if cond_arity == inner.arity() {
                         // If no additional columns were added, we simply return the
@@ -648,6 +774,7 @@ impl HirScalarExpr {
                             let then_expr = then_clone.applied_to(
                                 id_gen,
                                 col_map,
+                                cte_map,
                                 &mut then_inner,
                                 subquery_map,
                             );
@@ -672,6 +799,7 @@ impl HirScalarExpr {
                             let else_expr = else_clone.applied_to(
                                 id_gen,
                                 col_map,
+                                cte_map,
                                 &mut else_inner,
                                 subquery_map,
                             );
@@ -705,6 +833,7 @@ impl HirScalarExpr {
                         id_gen,
                         inner.take_dangerous(),
                         col_map,
+                        cte_map,
                         *expr,
                         apply_requires_distinct_outer,
                     );
@@ -717,6 +846,7 @@ impl HirScalarExpr {
                         id_gen,
                         inner.take_dangerous(),
                         col_map,
+                        cte_map,
                         *expr,
                         apply_requires_distinct_outer,
                     );
@@ -740,6 +870,7 @@ impl HirScalarExpr {
                                                 o.applied_to(
                                                     id_gen,
                                                     col_map,
+                                                    cte_map,
                                                     &mut get_inner,
                                                     subquery_map,
                                                 )
@@ -763,6 +894,7 @@ impl HirScalarExpr {
                                             let key = p.applied_to(
                                                 id_gen,
                                                 col_map,
+                                                cte_map,
                                                 &mut get_inner,
                                                 subquery_map,
                                             );
@@ -912,6 +1044,7 @@ impl HirScalarExpr {
         exprs: &[Self],
         id_gen: &mut ore::id_gen::IdGen,
         col_map: &ColumnMap,
+        cte_map: &mut CteMap,
         inner: expr::MirRelationExpr,
     ) -> (expr::MirRelationExpr, HashMap<HirScalarExpr, usize>) {
         let mut subquery_map = HashMap::new();
@@ -933,6 +1066,7 @@ impl HirScalarExpr {
                                 id_gen,
                                 distinct_inner.clone(),
                                 col_map,
+                                cte_map,
                                 (**expr).clone(),
                                 apply_requires_distinct_outer,
                             );
@@ -945,6 +1079,7 @@ impl HirScalarExpr {
                                 id_gen,
                                 distinct_inner.clone(),
                                 col_map,
+                                cte_map,
                                 (**expr).clone(),
                                 apply_requires_distinct_outer,
                             );
@@ -1055,6 +1190,7 @@ fn branch<F>(
     id_gen: &mut ore::id_gen::IdGen,
     outer: expr::MirRelationExpr,
     col_map: &ColumnMap,
+    cte_map: &mut CteMap,
     inner: HirRelationExpr,
     apply_requires_distinct_outer: bool,
     apply: F,
@@ -1065,6 +1201,7 @@ where
         HirRelationExpr,
         expr::MirRelationExpr,
         &ColumnMap,
+        &mut CteMap,
     ) -> expr::MirRelationExpr,
 {
     // TODO: It would be nice to have a version of this code w/o optimizations,
@@ -1126,7 +1263,7 @@ where
     if is_simple && !apply_requires_distinct_outer {
         let new_col_map = col_map.enter_scope(outer.arity() - col_map.len());
         return outer.let_in(id_gen, |id_gen, get_outer| {
-            apply(id_gen, inner, get_outer, &new_col_map)
+            apply(id_gen, inner, get_outer, &new_col_map, cte_map)
         });
     }
 
@@ -1147,6 +1284,39 @@ where
                 column: col.column,
             });
         }
+    });
+    // Collect all the outer columns referenced by any CTE referenced by
+    // the inner relation.
+    inner.visit(&mut |e| match e {
+        HirRelationExpr::Get {
+            id: expr::Id::Local(id),
+            ..
+        } => {
+            if let Some(cte_desc) = cte_map.get(id) {
+                let cte_outer_arity = cte_desc.outer_relation.arity();
+                outer_cols.extend(
+                    col_map
+                        .inner
+                        .iter()
+                        .filter(|(_, position)| **position < cte_outer_arity)
+                        .map(|(c, _)| {
+                            // Map the column to a column reference from within the
+                            // inner relation, ie. compensate for the -1 below.
+                            ColumnRef {
+                                level: c.level + 1,
+                                column: c.column,
+                            }
+                        }),
+                );
+            }
+        }
+        HirRelationExpr::Let { id, .. } => {
+            // Note: if ID uniqueness is not guaranteed, we can't use `visit` since
+            // we would need to remove the old CTE with the same ID temporarily while
+            // traversing the definition of the new CTE undet the same ID.
+            assert!(!cte_map.contains_key(id));
+        }
+        _ => {}
     });
     let mut new_col_map = HashMap::new();
     let mut key = vec![];
@@ -1173,7 +1343,7 @@ where
         };
         keyed_outer.let_in(id_gen, |id_gen, get_keyed_outer| {
             let oa = get_outer.arity();
-            let branch = apply(id_gen, inner, get_keyed_outer, &new_col_map);
+            let branch = apply(id_gen, inner, get_keyed_outer, &new_col_map, cte_map);
             let ba = branch.arity();
             let joined = expr::MirRelationExpr::join(
                 vec![get_outer.clone(), branch],
@@ -1193,6 +1363,7 @@ fn apply_scalar_subquery(
     id_gen: &mut ore::id_gen::IdGen,
     outer: expr::MirRelationExpr,
     col_map: &ColumnMap,
+    cte_map: &mut CteMap,
     scalar_subquery: HirRelationExpr,
     apply_requires_distinct_outer: bool,
 ) -> expr::MirRelationExpr {
@@ -1200,12 +1371,13 @@ fn apply_scalar_subquery(
         id_gen,
         outer,
         col_map,
+        cte_map,
         scalar_subquery,
         apply_requires_distinct_outer,
-        |id_gen, expr, get_inner, col_map| {
+        |id_gen, expr, get_inner, col_map, cte_map| {
             let select = expr
                 // compute for every row in get_inner
-                .applied_to(id_gen, get_inner.clone(), col_map);
+                .applied_to(id_gen, get_inner.clone(), col_map, cte_map);
             let col_type = select.typ().column_types.into_last();
 
             let inner_arity = get_inner.arity();
@@ -1247,6 +1419,7 @@ fn apply_existential_subquery(
     id_gen: &mut ore::id_gen::IdGen,
     outer: expr::MirRelationExpr,
     col_map: &ColumnMap,
+    cte_map: &mut CteMap,
     subquery_expr: HirRelationExpr,
     apply_requires_distinct_outer: bool,
 ) -> expr::MirRelationExpr {
@@ -1254,12 +1427,13 @@ fn apply_existential_subquery(
         id_gen,
         outer,
         col_map,
+        cte_map,
         subquery_expr,
         apply_requires_distinct_outer,
-        |id_gen, expr, get_inner, col_map| {
+        |id_gen, expr, get_inner, col_map, cte_map| {
             let exists = expr
                 // compute for every row in get_inner
-                .applied_to(id_gen, get_inner.clone(), col_map)
+                .applied_to(id_gen, get_inner.clone(), col_map, cte_map)
                 // throw away actual values and just remember whether or not there were __any__ rows
                 .distinct_by((0..get_inner.arity()).collect())
                 // Append true to anything that returned any rows. This
@@ -1283,6 +1457,7 @@ impl AggregateExpr {
         self,
         id_gen: &mut ore::id_gen::IdGen,
         col_map: &ColumnMap,
+        cte_map: &mut CteMap,
         inner: &mut expr::MirRelationExpr,
     ) -> expr::AggregateExpr {
         let AggregateExpr {
@@ -1293,7 +1468,7 @@ impl AggregateExpr {
 
         expr::AggregateExpr {
             func: func.into_expr(),
-            expr: expr.applied_to(id_gen, col_map, inner, &None),
+            expr: expr.applied_to(id_gen, col_map, cte_map, inner, &None),
             distinct,
         }
     }

--- a/src/sql/src/plan/optimize.rs
+++ b/src/sql/src/plan/optimize.rs
@@ -43,10 +43,9 @@ impl HirRelationExpr {
     pub fn optimize_and_lower(self, config: &OptimizerConfig) -> expr::MirRelationExpr {
         if config.qgm_optimizations {
             // create a query graph model from this HirRelationExpr
-            let model = Model::from(self);
+            let mut model = Model::from(self);
 
-            // @todo: perform optimizing algebraic rewrites on the qgm
-            // ...
+            crate::query_model::rewrite_engine::rewrite_model(&mut model);
 
             // decorrelate and lower the optimized query graph model into a MirRelationExpr
             model.lower()

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1195,15 +1195,8 @@ fn plan_query_inner(
 
         match cte.id {
             Id::Local(id) => {
-                let old_val = qcx.ctes.insert(
-                    id,
-                    CteDesc {
-                        val,
-                        val_desc,
-                        level_offset: 0,
-                    },
-                );
-                old_cte_values.push((cte_name, old_val));
+                let old_val = qcx.ctes.insert(id, CteDesc { val, val_desc });
+                old_cte_values.push((id, old_val));
             }
             _ => unreachable!(),
         }
@@ -1229,7 +1222,7 @@ fn plan_query_inner(
         _ => sql_bail!("OFFSET must be an integer constant"),
     };
 
-    let result = match &q.body {
+    let (mut result, scope, finishing) = match &q.body {
         SetExpr::Select(s) => {
             let plan = plan_view_select(qcx, s, &q.order_by)?;
             let finishing = RowSetFinishing {
@@ -1238,7 +1231,7 @@ fn plan_query_inner(
                 limit,
                 offset,
             };
-            Ok((plan.expr, plan.scope, finishing))
+            Ok::<_, PlanError>((plan.expr, plan.scope, finishing))
         }
         _ => {
             let (expr, scope) = plan_set_expr(qcx, &q.body)?;
@@ -1260,9 +1253,22 @@ fn plan_query_inner(
             };
             Ok((expr.map(map_exprs), scope, finishing))
         }
-    };
+    }?;
 
-    result
+    for (id, old_val) in old_cte_values.into_iter().rev() {
+        if let Some(cte) = qcx.ctes.remove(&id) {
+            result = HirRelationExpr::Let {
+                id: id.clone(),
+                value: Box::new(cte.val),
+                body: Box::new(result),
+            };
+        }
+        if let Some(old_val) = old_val {
+            qcx.ctes.insert(id, old_val);
+        }
+    }
+
+    Ok((result, scope, finishing))
 }
 
 pub fn plan_nested_query(
@@ -3999,11 +4005,6 @@ pub struct CteDesc {
     /// The CTE's expression.
     val: HirRelationExpr,
     val_desc: RelationDesc,
-    /// We evaluate CTEs when they're defined and not when they're referred to
-    /// (i.e. it's like a pointer, not a macro). This means that we need to
-    /// adjust the level of correlated columns to retain their original
-    /// references.
-    level_offset: usize,
 }
 
 /// The state required when planning a `Query`.
@@ -4050,11 +4051,7 @@ impl<'a> QueryContext<'a> {
     /// Generate a new `QueryContext` appropriate to be used in subqueries of
     /// `self`.
     fn derived_context(&self, scope: Scope, relation_type: RelationType) -> QueryContext<'a> {
-        let mut ctes = self.ctes.clone();
-        for (_, cte) in ctes.iter_mut() {
-            cte.level_offset += 1;
-        }
-
+        let ctes = self.ctes.clone();
         let outer_scopes = iter::once(scope).chain(self.outer_scopes.clone()).collect();
         let outer_relation_types = iter::once(relation_type)
             .chain(self.outer_relation_types.clone())
@@ -4088,20 +4085,15 @@ impl<'a> QueryContext<'a> {
             Id::Local(id) => {
                 let name = object.raw_name;
                 let cte = self.ctes.get(&id).unwrap();
-                let mut val = cte.val.clone();
-                val.visit_columns_mut(0, &mut |depth, col| {
-                    if col.level > depth {
-                        col.level += cte.level_offset;
-                    }
-                });
+                let expr = HirRelationExpr::Get {
+                    id: Id::Local(id),
+                    typ: cte.val_desc.typ().clone(),
+                };
 
                 let scope =
                     Scope::from_source(Some(name), cte.val_desc.iter_names().map(|n| n.cloned()));
 
-                // Inline `val` where its name was referenced. In an ideal
-                // world, multiple instances of this expression would be
-                // de-duplicated.
-                Ok((val, scope))
+                Ok((expr, scope))
             }
             Id::Global(id) => {
                 let item = self.scx.get_item_by_id(&id);

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -174,6 +174,7 @@ pub fn describe_explain(
         StatementDesc::new(Some(RelationDesc::empty().with_named_column(
             match stage {
                 ExplainStage::RawPlan => "Raw Plan",
+                ExplainStage::QueryGraph => "Query Graph",
                 ExplainStage::DecorrelatedPlan => "Decorrelated Plan",
                 ExplainStage::OptimizedPlan { .. } => "Optimized Plan",
                 ExplainStage::PhysicalPlan => "Physical Plan",

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -175,6 +175,7 @@ pub fn describe_explain(
             match stage {
                 ExplainStage::RawPlan => "Raw Plan",
                 ExplainStage::QueryGraph => "Query Graph",
+                ExplainStage::OptimizedQueryGraph => "Optimized Query Graph",
                 ExplainStage::DecorrelatedPlan => "Decorrelated Plan",
                 ExplainStage::OptimizedPlan { .. } => "Optimized Plan",
                 ExplainStage::PhysicalPlan => "Physical Plan",

--- a/src/sql/src/query_model/dot.rs
+++ b/src/sql/src/query_model/dot.rs
@@ -9,7 +9,7 @@
 
 //! Generates a graphviz graph from a Query Graph Model.
 
-use crate::query_model::{BoxType, Model, Quantifier, QuantifierId, QueryBox};
+use crate::query_model::{BoxId, BoxType, Model, Quantifier, QuantifierId, QueryBox};
 use itertools::Itertools;
 use ore::str::separated;
 use std::collections::BTreeMap;
@@ -46,7 +46,17 @@ impl DotGenerator {
     }
 
     /// Generates a graphviz graph for the given model, labeled with `label`.
-    pub fn generate(mut self, model: &Model, label: &str) -> Result<String, anyhow::Error> {
+    pub fn generate(self, model: &Model, label: &str) -> Result<String, anyhow::Error> {
+        self.generate_subgraph(model, model.top_box, label)
+    }
+
+    /// Generates a graphviz graph for the given subgraph of the model, labeled with `label`.
+    pub fn generate_subgraph(
+        mut self,
+        model: &Model,
+        start_box: BoxId,
+        label: &str,
+    ) -> Result<String, anyhow::Error> {
         self.new_line("digraph G {");
         self.inc();
         self.new_line("compound = true");
@@ -59,54 +69,57 @@ impl DotGenerator {
         let mut quantifiers = Vec::new();
 
         model
-            .visit_pre_boxes(&mut |b| -> Result<(), ()> {
-                let box_id = b.id;
+            .visit_pre_boxes_in_subgraph(
+                &mut |b| -> Result<(), ()> {
+                    let box_id = b.id;
 
-                self.new_line(&format!("subgraph cluster{} {{", box_id));
-                self.inc();
-                self.new_line(
-                    &DotLabel::SingleRow(&format!("Box{}:{}", box_id, Self::get_box_title(&b)))
-                        .to_string(),
-                );
-                self.new_line(&format!(
-                    "boxhead{} [ shape = record, {} ]",
-                    box_id,
-                    Self::get_box_head(&b)
-                ));
-
-                self.new_line("{");
-                self.inc();
-                self.new_line("rank = same");
-
-                if b.quantifiers.len() > 0 {
-                    self.new_line("node [ shape = circle ]");
-                }
-
-                for q_id in b.quantifiers.iter() {
-                    quantifiers.push(*q_id);
-
-                    let q = model.get_quantifier(*q_id);
+                    self.new_line(&format!("subgraph cluster{} {{", box_id));
+                    self.inc();
+                    self.new_line(
+                        &DotLabel::SingleRow(&format!("Box{}:{}", box_id, Self::get_box_title(&b)))
+                            .to_string(),
+                    );
                     self.new_line(&format!(
-                        "Q{0} [ {1} ]",
-                        q_id,
-                        DotLabel::SingleRow(&format!(
-                            "Q{0}({1}){2}",
-                            q_id,
-                            q.quantifier_type,
-                            Self::get_quantifier_alias(&q)
-                        ))
+                        "boxhead{} [ shape = record, {} ]",
+                        box_id,
+                        Self::get_box_head(&b)
                     ));
-                }
 
-                self.add_correlation_info(model, &b);
+                    self.new_line("{");
+                    self.inc();
+                    self.new_line("rank = same");
 
-                self.dec();
-                self.new_line("}");
-                self.dec();
-                self.new_line("}");
+                    if b.quantifiers.len() > 0 {
+                        self.new_line("node [ shape = circle ]");
+                    }
 
-                Ok(())
-            })
+                    for q_id in b.quantifiers.iter() {
+                        quantifiers.push(*q_id);
+
+                        let q = model.get_quantifier(*q_id);
+                        self.new_line(&format!(
+                            "Q{0} [ {1} ]",
+                            q_id,
+                            DotLabel::SingleRow(&format!(
+                                "Q{0}({1}){2}",
+                                q_id,
+                                q.quantifier_type,
+                                Self::get_quantifier_alias(&q)
+                            ))
+                        ));
+                    }
+
+                    self.add_correlation_info(model, &b);
+
+                    self.dec();
+                    self.new_line("}");
+                    self.dec();
+                    self.new_line("}");
+
+                    Ok(())
+                },
+                start_box,
+            )
             .unwrap();
 
         if quantifiers.len() > 0 {

--- a/src/sql/src/query_model/dot.rs
+++ b/src/sql/src/query_model/dot.rs
@@ -9,8 +9,6 @@
 
 //! Generates a graphviz graph from a Query Graph Model.
 
-#![cfg(test)]
-
 use crate::query_model::{BoxType, Model, Quantifier, QuantifierId, QueryBox};
 use itertools::Itertools;
 use ore::str::separated;
@@ -19,7 +17,8 @@ use std::fmt::{self, Write};
 
 /// Generates a graphviz graph from a Query Graph Model, defined in the DOT language.
 /// See <https://graphviz.org/doc/info/lang.html>.
-pub(crate) struct DotGenerator {
+#[derive(Debug)]
+pub struct DotGenerator {
     output: String,
     indent: u32,
 }

--- a/src/sql/src/query_model/hir.rs
+++ b/src/sql/src/query_model/hir.rs
@@ -86,6 +86,18 @@ impl FromHir {
                     panic!("unsupported get id {:?}", id);
                 }
             }
+            HirRelationExpr::Let { id, value, body } => {
+                let id = expr::Id::Local(id);
+                let value_box = self.generate_internal(*value);
+                let prev_value = self.gets_seen.insert(id.clone(), value_box);
+                let body_box = self.generate_internal(*body);
+                if let Some(prev_value) = prev_value {
+                    self.gets_seen.insert(id, prev_value);
+                } else {
+                    self.gets_seen.remove(&id);
+                }
+                body_box
+            }
             HirRelationExpr::Constant { rows, typ } => {
                 assert!(typ.arity() == 0, "expressions are not yet supported",);
                 self.model.make_box(BoxType::Values(Values {

--- a/src/sql/src/query_model/hir.rs
+++ b/src/sql/src/query_model/hir.rs
@@ -192,7 +192,7 @@ impl FromHir {
                     });
                     // Add it to the grouping key and to the projection of the
                     // Grouping box
-                    key.push(Box::new(select_box_col_ref.clone()));
+                    key.push(select_box_col_ref.clone());
                     self.model
                         .get_mut_box(group_box_id)
                         .add_column(select_box_col_ref);
@@ -440,8 +440,8 @@ impl FromHir {
     fn add_predicate(&mut self, box_id: BoxId, predicate: BoxScalarExpr) {
         let mut the_box = self.model.get_mut_box(box_id);
         match &mut the_box.box_type {
-            BoxType::Select(select) => select.predicates.push(Box::new(predicate)),
-            BoxType::OuterJoin(outer_join) => outer_join.predicates.push(Box::new(predicate)),
+            BoxType::Select(select) => select.predicates.push(predicate),
+            BoxType::OuterJoin(outer_join) => outer_join.predicates.push(predicate),
             _ => unreachable!(),
         }
     }

--- a/src/sql/src/query_model/hir.rs
+++ b/src/sql/src/query_model/hir.rs
@@ -124,7 +124,7 @@ impl FromHir {
                     for scalar in scalars.drain(0..end_idx) {
                         let expr = self.generate_expr(scalar, box_id);
                         let mut b = self.model.get_mut_box(box_id);
-                        b.columns.push(Column { expr, alias: None });
+                        b.add_column(expr);
                     }
 
                     // 3) If there are scalars remaining, wrap the box so the
@@ -181,10 +181,9 @@ impl FromHir {
                     // Add it to the grouping key and to the projection of the
                     // Grouping box
                     key.push(Box::new(select_box_col_ref.clone()));
-                    self.model.get_mut_box(group_box_id).columns.push(Column {
-                        expr: select_box_col_ref,
-                        alias: None,
-                    });
+                    self.model
+                        .get_mut_box(group_box_id)
+                        .add_column(select_box_col_ref);
                 }
                 for aggregate in aggregates.into_iter() {
                     // Any computed expression passed as an argument of an aggregate
@@ -206,10 +205,7 @@ impl FromHir {
                         expr: Box::new(col_ref),
                         distinct: aggregate.distinct,
                     };
-                    self.model.get_mut_box(group_box_id).columns.push(Column {
-                        expr: aggregate,
-                        alias: None,
-                    });
+                    self.model.get_mut_box(group_box_id).add_column(aggregate);
                 }
 
                 // Update the key of the grouping box
@@ -242,13 +238,10 @@ impl FromHir {
                         .make_quantifier(QuantifierType::Foreach, input_box_id, select_id);
                 let mut select_box = self.model.get_mut_box(select_id);
                 for position in outputs {
-                    select_box.columns.push(Column {
-                        expr: BoxScalarExpr::ColumnReference(ColumnReference {
-                            quantifier_id,
-                            position,
-                        }),
-                        alias: None,
-                    });
+                    select_box.add_column(BoxScalarExpr::ColumnReference(ColumnReference {
+                        quantifier_id,
+                        position,
+                    }));
                 }
                 select_id
             }

--- a/src/sql/src/query_model/hir.rs
+++ b/src/sql/src/query_model/hir.rs
@@ -374,6 +374,26 @@ impl FromHir {
                     position: 0,
                 })
             }
+            HirScalarExpr::Windowing(expr) => {
+                let func = match expr.func {
+                    crate::plan::expr::WindowExprType::Scalar(scalar) => {
+                        crate::query_model::scalar_expr::WindowExprType::Scalar(scalar.func)
+                    }
+                };
+                BoxScalarExpr::Windowing(crate::query_model::WindowExpr {
+                    func,
+                    partition: expr
+                        .partition
+                        .into_iter()
+                        .map(|e| self.generate_expr(e, context_box))
+                        .collect(),
+                    order_by: expr
+                        .order_by
+                        .into_iter()
+                        .map(|e| self.generate_expr(e, context_box))
+                        .collect(),
+                })
+            }
             _ => panic!("unsupported expression type {:?}", expr),
         }
     }

--- a/src/sql/src/query_model/hir.rs
+++ b/src/sql/src/query_model/hir.rs
@@ -59,12 +59,11 @@ impl FromHir {
 
     /// Generates a sub-graph representing the given expression.
     fn generate_internal(&mut self, expr: HirRelationExpr) -> BoxId {
-        match expr {
+        let result = match expr {
             HirRelationExpr::Get { id, mut typ } => {
                 if let Some(box_id) = self.gets_seen.get(&id) {
-                    return *box_id;
-                }
-                if let expr::Id::Global(id) = id {
+                    *box_id
+                } else if let expr::Id::Global(id) = id {
                     let result = self.model.make_box(BoxType::Get(Get { id }));
                     let mut b = self.model.get_mut_box(result);
                     self.gets_seen.insert(expr::Id::Global(id), result);
@@ -312,7 +311,9 @@ impl FromHir {
             }
 
             _ => panic!("unsupported expression type {:?}", expr),
-        }
+        };
+        self.model.update_computed_properties(result);
+        result
     }
 
     /// Returns a Select box ranging over the given box, projecting

--- a/src/sql/src/query_model/lowering.rs
+++ b/src/sql/src/query_model/lowering.rs
@@ -204,7 +204,7 @@ impl<'a> Lowerer<'a> {
                         grouping
                             .key
                             .iter()
-                            .position(|k| c.expr == **k)
+                            .position(|k| c.expr == *k)
                             .expect("expression in the projection of a Grouping box not included in the grouping key")
                     }
                 }).collect_vec();

--- a/src/sql/src/query_model/mod.rs
+++ b/src/sql/src/query_model/mod.rs
@@ -14,7 +14,7 @@ use std::fmt;
 
 use ore::id_gen::Gen;
 
-mod dot;
+pub mod dot;
 mod hir;
 mod lowering;
 mod scalar_expr;

--- a/src/sql/src/query_model/mod.rs
+++ b/src/sql/src/query_model/mod.rs
@@ -536,6 +536,14 @@ impl QueryBox {
         matches!(self.box_type, BoxType::Select(_))
     }
 
+    /// Note: data sources can only contain BaseColumns in their projections.
+    fn is_data_source(&self) -> bool {
+        matches!(
+            self.box_type,
+            BoxType::Get(_) | BoxType::TableFunction(_) | BoxType::Values(_)
+        )
+    }
+
     fn add_predicate(&mut self, predicate: Box<BoxScalarExpr>) {
         match &mut self.box_type {
             BoxType::Select(select) => select.predicates.push(predicate),

--- a/src/sql/src/query_model/mod.rs
+++ b/src/sql/src/query_model/mod.rs
@@ -179,6 +179,8 @@ pub enum BoxType {
     /// Operator that produces a set of rows, with potentially
     /// correlated values.
     Values(Values),
+    /// Windowing operator
+    Windowing,
 }
 
 #[derive(Debug, Clone)]
@@ -590,7 +592,11 @@ impl QueryBox {
                     f(p)?;
                 }
             }
-            BoxType::Except | BoxType::Union | BoxType::Intersect | BoxType::Get(_) => {}
+            BoxType::Windowing
+            | BoxType::Except
+            | BoxType::Union
+            | BoxType::Intersect
+            | BoxType::Get(_) => {}
         }
         Ok(())
     }
@@ -642,7 +648,11 @@ impl QueryBox {
                     f(p)?;
                 }
             }
-            BoxType::Except | BoxType::Union | BoxType::Intersect | BoxType::Get(_) => {}
+            BoxType::Windowing
+            | BoxType::Except
+            | BoxType::Union
+            | BoxType::Intersect
+            | BoxType::Get(_) => {}
         }
         Ok(())
     }
@@ -730,6 +740,7 @@ impl BoxType {
             BoxType::TableFunction(..) => "TableFunction",
             BoxType::Union => "Union",
             BoxType::Values(..) => "Values",
+            BoxType::Windowing => "Windowing",
         }
     }
 }

--- a/src/sql/src/query_model/mod.rs
+++ b/src/sql/src/query_model/mod.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use itertools::Itertools;
 use std::cell::{Ref, RefCell, RefMut};
 use std::collections::BTreeSet;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -446,6 +447,59 @@ impl Model {
         self.boxes.retain(|b, _| visited_boxes.contains(b));
         self.quantifiers
             .retain(|q, _| visited_quantifiers.contains(q));
+    }
+
+    /// Updates the IDs of all the objects in the graph
+    fn update_ids(&mut self) {
+        self.box_id_gen = Default::default();
+        self.quantifier_id_gen = Default::default();
+
+        let quantifier_map = self
+            .quantifiers
+            .iter()
+            .map(|(q_id, _)| *q_id)
+            .sorted()
+            .map(|q_id| (q_id, self.quantifier_id_gen.allocate_id()))
+            .collect::<HashMap<QuantifierId, QuantifierId>>();
+        let box_map = self
+            .boxes
+            .iter()
+            .map(|(box_id, _)| *box_id)
+            .sorted()
+            .map(|box_id| (box_id, self.box_id_gen.allocate_id()))
+            .collect::<HashMap<BoxId, BoxId>>();
+
+        self.quantifiers = self
+            .quantifiers
+            .drain()
+            .map(|(q_id, q)| {
+                let new_id = *quantifier_map.get(&q_id).unwrap();
+                let mut b_q = q.borrow_mut();
+                b_q.id = new_id;
+                b_q.input_box = *box_map.get(&b_q.input_box).unwrap();
+                drop(b_q);
+                (new_id, q)
+            })
+            .collect();
+        self.boxes = self
+            .boxes
+            .drain()
+            .map(|(box_id, b)| {
+                let new_id = *box_map.get(&box_id).unwrap();
+                let mut b_b = b.borrow_mut();
+                b_b.id = new_id;
+                b_b.quantifiers = b_b
+                    .quantifiers
+                    .iter()
+                    .map(|q_id| *quantifier_map.get(q_id).unwrap())
+                    .collect();
+                b_b.remap_column_references(&quantifier_map);
+                drop(b_b);
+                (new_id, b)
+            })
+            .collect();
+
+        self.top_box = *box_map.get(&self.top_box).unwrap();
     }
 }
 

--- a/src/sql/src/query_model/mod.rs
+++ b/src/sql/src/query_model/mod.rs
@@ -191,23 +191,23 @@ pub struct Get {
 /// The content of a Grouping box.
 #[derive(Debug, Default, Clone)]
 pub struct Grouping {
-    pub key: Vec<Box<BoxScalarExpr>>,
+    pub key: Vec<BoxScalarExpr>,
 }
 
 /// The content of a OuterJoin box.
 #[derive(Debug, Default, Clone)]
 pub struct OuterJoin {
     /// The predices in the ON clause of the outer join.
-    pub predicates: Vec<Box<BoxScalarExpr>>,
+    pub predicates: Vec<BoxScalarExpr>,
 }
 
 /// The content of a Select box.
 #[derive(Debug, Default, Clone)]
 pub struct Select {
     /// The list of predicates applied by the box.
-    pub predicates: Vec<Box<BoxScalarExpr>>,
+    pub predicates: Vec<BoxScalarExpr>,
     /// An optional ORDER BY key
-    pub order_key: Option<Vec<Box<BoxScalarExpr>>>,
+    pub order_key: Option<Vec<BoxScalarExpr>>,
     /// An optional LIMIT clause
     pub limit: Option<BoxScalarExpr>,
     /// An optional OFFSET clause
@@ -216,13 +216,13 @@ pub struct Select {
 
 #[derive(Debug, Default, Clone)]
 pub struct TableFunction {
-    pub parameters: Vec<Box<BoxScalarExpr>>,
+    pub parameters: Vec<BoxScalarExpr>,
     // @todo function metadata from the catalog
 }
 
 #[derive(Debug, Default, Clone)]
 pub struct Values {
-    pub rows: Vec<Vec<Box<BoxScalarExpr>>>,
+    pub rows: Vec<Vec<BoxScalarExpr>>,
 }
 
 impl Model {
@@ -694,7 +694,7 @@ impl QueryBox {
         )
     }
 
-    fn add_predicate(&mut self, predicate: Box<BoxScalarExpr>) {
+    fn add_predicate(&mut self, predicate: BoxScalarExpr) {
         match &mut self.box_type {
             BoxType::Select(select) => select.predicates.push(predicate),
             BoxType::OuterJoin(outer_join) => outer_join.predicates.push(predicate),
@@ -702,7 +702,7 @@ impl QueryBox {
         }
     }
 
-    fn get_predicates(&self) -> Option<&Vec<Box<BoxScalarExpr>>> {
+    fn get_predicates(&self) -> Option<&Vec<BoxScalarExpr>> {
         match &self.box_type {
             BoxType::Select(select) => Some(&select.predicates),
             BoxType::OuterJoin(outer_join) => Some(&outer_join.predicates),

--- a/src/sql/src/query_model/mod.rs
+++ b/src/sql/src/query_model/mod.rs
@@ -777,3 +777,14 @@ impl fmt::Display for QuantifierType {
         }
     }
 }
+
+impl Select {
+    fn new() -> Self {
+        Self {
+            predicates: Vec::new(),
+            order_key: None,
+            limit: None,
+            offset: None,
+        }
+    }
+}

--- a/src/sql/src/query_model/mod.rs
+++ b/src/sql/src/query_model/mod.rs
@@ -379,6 +379,13 @@ impl QueryBox {
         }
     }
 
+    /// Append the given expression as a new column in the projection of the box.
+    fn add_column(&mut self, expr: BoxScalarExpr) -> usize {
+        let position = self.columns.len();
+        self.columns.push(Column { expr, alias: None });
+        position
+    }
+
     /// Append the given expression as a new column in the projection of the box
     /// if there isn't already a column with the same expression. Returns the
     /// position of the first column in the projection with the same expression.
@@ -386,9 +393,7 @@ impl QueryBox {
         if let Some(position) = self.columns.iter().position(|c| c.expr == expr) {
             position
         } else {
-            let position = self.columns.len();
-            self.columns.push(Column { expr, alias: None });
-            position
+            self.add_column(expr)
         }
     }
 

--- a/src/sql/src/query_model/mod.rs
+++ b/src/sql/src/query_model/mod.rs
@@ -298,6 +298,18 @@ impl Model {
         new_id
     }
 
+    fn swap_quantifiers(&mut self, b1: BoxId, b2: BoxId) {
+        let mut b1_b = self.get_mut_box(b1);
+        let mut b2_b = self.get_mut_box(b2);
+        std::mem::swap(&mut b1_b.quantifiers, &mut b2_b.quantifiers);
+        for q_id in b1_b.quantifiers.iter() {
+            self.get_mut_quantifier(*q_id).parent_box = b1;
+        }
+        for q_id in b2_b.quantifiers.iter() {
+            self.get_mut_quantifier(*q_id).parent_box = b2;
+        }
+    }
+
     /// Get an immutable reference to the box identified by `box_id`.
     fn get_box(&self, box_id: BoxId) -> Ref<'_, QueryBox> {
         self.boxes

--- a/src/sql/src/query_model/mod.rs
+++ b/src/sql/src/query_model/mod.rs
@@ -103,14 +103,14 @@ pub struct QueryBox {
 }
 
 /// A column projected by a `QueryBox`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Column {
     pub expr: BoxScalarExpr,
     pub alias: Option<Ident>,
 }
 
 /// Enum that describes the DISTINCT property of a `QueryBox`.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum DistinctOperation {
     /// Distinctness of the output of the box must be enforced by
     /// the box.
@@ -138,7 +138,7 @@ pub struct Quantifier {
     pub alias: Option<Ident>,
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum QuantifierType {
     /// An ALL subquery.
     All,
@@ -154,7 +154,7 @@ pub enum QuantifierType {
     Scalar,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum BoxType {
     /// A table from the catalog.
     Get(Get),
@@ -180,26 +180,26 @@ pub enum BoxType {
     Values(Values),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Get {
     id: expr::GlobalId,
 }
 
 /// The content of a Grouping box.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Grouping {
     pub key: Vec<Box<BoxScalarExpr>>,
 }
 
 /// The content of a OuterJoin box.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct OuterJoin {
     /// The predices in the ON clause of the outer join.
     pub predicates: Vec<Box<BoxScalarExpr>>,
 }
 
 /// The content of a Select box.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Select {
     /// The list of predicates applied by the box.
     pub predicates: Vec<Box<BoxScalarExpr>>,
@@ -211,13 +211,13 @@ pub struct Select {
     pub offset: Option<BoxScalarExpr>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct TableFunction {
     pub parameters: Vec<Box<BoxScalarExpr>>,
     // @todo function metadata from the catalog
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Values {
     pub rows: Vec<Vec<Box<BoxScalarExpr>>>,
 }
@@ -250,6 +250,49 @@ impl Model {
 
     fn make_select_box(&mut self) -> BoxId {
         self.make_box(BoxType::Select(Select::default()))
+    }
+
+    /// Performs a shallow clone of the box
+    /// Note: correlated referenced are not updated, because that would require a deep clone.
+    fn clone_box(&mut self, box_id: BoxId) -> BoxId {
+        let new_id = self.box_id_gen.allocate_id();
+
+        let (new_box, quantifiers_to_clone) = {
+            let source_box = self.get_box(box_id);
+            let b = Box::new(RefCell::new(QueryBox {
+                id: new_id,
+                box_type: source_box.box_type.clone(),
+                columns: source_box.columns.clone(),
+                quantifiers: QuantifierSet::new(),
+                ranging_quantifiers: QuantifierSet::new(),
+                unique_keys: source_box.unique_keys.clone(),
+                distinct: source_box.distinct,
+            }));
+            (b, source_box.quantifiers.clone())
+        };
+        // Insert the box in order for `make_quantifier` to find it.
+        self.boxes.insert(new_id, new_box);
+        let cloned_quantifiers = quantifiers_to_clone
+            .iter()
+            .map(|q| {
+                let (quantifier_type, input_box) = {
+                    let q = self.get_quantifier(*q);
+                    (q.quantifier_type.clone(), q.input_box)
+                };
+                self.make_quantifier(quantifier_type, input_box, new_id)
+            })
+            .collect::<QuantifierSet>();
+        // Update any column reference within the cloned box to point to the
+        // new quantifiers
+        let quantifier_map = quantifiers_to_clone
+            .iter()
+            .zip(cloned_quantifiers.iter())
+            .map(|(old, new)| (*old, *new))
+            .collect::<HashMap<_, _>>();
+        let mut cloned_box = self.get_mut_box(new_id);
+        cloned_box.remap_column_references(&quantifier_map);
+        cloned_box.quantifiers = cloned_quantifiers;
+        new_id
     }
 
     /// Get an immutable reference to the box identified by `box_id`.
@@ -287,6 +330,24 @@ impl Model {
         self.get_mut_box(parent_box).quantifiers.insert(id);
         self.get_mut_box(input_box).ranging_quantifiers.insert(id);
         id
+    }
+
+    /// Sets the input box of the given quantifier
+    fn update_input_box(&self, quantifier_id: QuantifierId, input_box: BoxId) {
+        let old_input_box = {
+            let mut q = self.get_mut_quantifier(quantifier_id);
+            let old_input_box = q.input_box;
+            q.input_box = input_box;
+            old_input_box
+        };
+
+        self.get_mut_box(old_input_box)
+            .ranging_quantifiers
+            .remove(&quantifier_id);
+
+        self.get_mut_box(input_box)
+            .ranging_quantifiers
+            .insert(quantifier_id);
     }
 
     /// Get an immutable reference to the box identified by `box_id`.
@@ -530,6 +591,19 @@ impl QueryBox {
             BoxType::Except | BoxType::Union | BoxType::Intersect | BoxType::Get(_) => {}
         }
         Ok(())
+    }
+
+    fn remap_column_references(&mut self, quantifier_map: &HashMap<QuantifierId, QuantifierId>) {
+        let _ = self.visit_expressions_mut(&mut |expr: &mut BoxScalarExpr| -> Result<(), ()> {
+            expr.visit_mut(&mut |expr| {
+                if let BoxScalarExpr::ColumnReference(c) = expr {
+                    if let Some(new_quantifier) = quantifier_map.get(&c.quantifier_id) {
+                        c.quantifier_id = *new_quantifier;
+                    }
+                }
+            });
+            Ok(())
+        });
     }
 
     fn is_select(&self) -> bool {

--- a/src/sql/src/query_model/rewrite_engine.rs
+++ b/src/sql/src/query_model/rewrite_engine.rs
@@ -54,6 +54,8 @@ pub fn rewrite_model(model: &mut Model) {
     apply_rules_to_model(model, &mut decorrelation_rules);
 
     model.garbage_collect();
+
+    model.update_ids();
 }
 
 /// Transform the model by applying a list of rewrite rules.

--- a/src/sql/src/query_model/rewrite_engine.rs
+++ b/src/sql/src/query_model/rewrite_engine.rs
@@ -1,0 +1,192 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::query_model::{
+    BoxId, BoxScalarExpr, BoxType, DistinctOperation, Model, QuantifierSet, QuantifierType,
+};
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+/// Rule type
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum RuleType {
+    TopBoxOnly,
+    PreOrder,
+    PostOrder,
+}
+
+/// Trait for rewrite rules
+pub trait Rule {
+    fn name(&self) -> &'static str;
+
+    fn rule_type(&self) -> RuleType;
+
+    /// Whether the action should be fired for the given box.
+    /// This method is not allowed to modify the model in any way.
+    fn condition(&mut self, model: &Model, box_id: BoxId) -> bool;
+
+    /// Invoked immediately after `condition` if it returned true.
+    fn action(&mut self, model: &mut Model, box_id: BoxId);
+}
+
+/// Entry-point of the normalization stage.
+pub fn rewrite_model(model: &mut Model) {
+    let mut rules: Vec<Box<dyn Rule>> = vec![Box::new(SelectMerge::new())];
+
+    apply_rules_to_model(model, &mut rules);
+
+    model.garbage_collect();
+}
+
+/// Transform the model by applying a list of rewrite rules.
+pub fn apply_rules_to_model(model: &mut Model, rules: &mut Vec<Box<dyn Rule>>) {
+    for rule in rules
+        .iter_mut()
+        .filter(|r| matches!(r.rule_type(), RuleType::TopBoxOnly))
+    {
+        apply_rule(&mut **rule, model, model.top_box);
+    }
+
+    deep_apply_rules(rules, model, model.top_box, &mut HashSet::new());
+}
+
+/// Apply a rewrite rule to a given box within the Model if it matches the condition.
+fn apply_rule(rule: &mut dyn Rule, model: &mut Model, box_id: BoxId) {
+    if rule.condition(model, box_id) {
+        rule.action(model, box_id);
+    }
+}
+
+/// Descend and apply recursively the given list of rewrite rules to all boxes within
+/// the subgraph starting in the given box. `visited_boxes` keeps track of all the
+/// visited boxes so far, to avoid visiting them again.
+fn deep_apply_rules(
+    rules: &mut Vec<Box<dyn Rule>>,
+    model: &mut Model,
+    box_id: BoxId,
+    visited_boxes: &mut HashSet<BoxId>,
+) {
+    if visited_boxes.insert(box_id) {
+        for rule in rules
+            .iter_mut()
+            .filter(|r| matches!(r.rule_type(), RuleType::PreOrder))
+        {
+            apply_rule(&mut **rule, model, box_id);
+        }
+
+        let quantifiers = model.get_box(box_id).quantifiers.clone();
+        for q_id in quantifiers {
+            let input_box = model.get_quantifier(q_id).input_box;
+            deep_apply_rules(rules, model, input_box, visited_boxes);
+        }
+
+        for rule in rules
+            .iter_mut()
+            .filter(|r| matches!(r.rule_type(), RuleType::PostOrder))
+        {
+            apply_rule(&mut **rule, model, box_id);
+        }
+    }
+}
+
+/// Merges nested select boxes.
+struct SelectMerge {
+    to_merge: QuantifierSet,
+}
+
+impl SelectMerge {
+    fn new() -> Self {
+        Self {
+            /// Set of quantifiers to be removed from the current box
+            to_merge: BTreeSet::new(),
+        }
+    }
+}
+
+impl Rule for SelectMerge {
+    fn name(&self) -> &'static str {
+        "SelectMerge"
+    }
+
+    fn rule_type(&self) -> RuleType {
+        RuleType::PostOrder
+    }
+
+    fn condition(&mut self, model: &Model, box_id: BoxId) -> bool {
+        self.to_merge.clear();
+        let outer_box = model.get_box(box_id);
+        if let BoxType::Select(_outer_select) = &outer_box.box_type {
+            for q_id in outer_box.quantifiers.iter() {
+                let q = model.get_quantifier(*q_id);
+
+                // Only Select boxes under Foreach quantifiers can be merged
+                // into the parent Select box.
+                if let QuantifierType::Foreach = q.quantifier_type {
+                    let input_box = model.get_box(q.input_box);
+
+                    // TODO(asenac) clone shared boxes
+                    if input_box.ranging_quantifiers.len() == 1 {
+                        if let BoxType::Select(inner_select) = &input_box.box_type {
+                            if input_box.distinct != DistinctOperation::Enforce
+                                && inner_select.order_key.is_none()
+                                && inner_select.limit.is_none()
+                            {
+                                self.to_merge.insert(*q_id);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        !self.to_merge.is_empty()
+    }
+
+    fn action(&mut self, model: &mut Model, box_id: BoxId) {
+        // Dereference all the expressions in the sub-graph referencing the quantifiers
+        // that are about to be squashed into the current box.
+        let _ = model.visit_pre_boxes_in_subgraph_mut(
+            &mut |mut b| -> Result<(), ()> {
+                b.visit_expressions_mut(&mut |expr: &mut BoxScalarExpr| -> Result<(), ()> {
+                    expr.visit_mut(&mut |expr| {
+                        if let BoxScalarExpr::ColumnReference(c) = expr {
+                            if self.to_merge.contains(&c.quantifier_id) {
+                                let inner_box = model.get_quantifier(c.quantifier_id).input_box;
+                                let inner_box = model.get_box(inner_box);
+
+                                *expr = inner_box.columns[c.position].expr.clone();
+                            }
+                        }
+                    });
+                    Ok(())
+                })?;
+                Ok(())
+            },
+            box_id,
+        );
+
+        // Add all the quantifiers in the input boxes of the quantifiers to be
+        // merged into the current box
+        let mut outer_box = model.get_mut_box(box_id);
+        for q_id in self.to_merge.iter() {
+            outer_box.quantifiers.remove(q_id);
+
+            let input_box_id = model.get_mut_quantifier(*q_id).input_box;
+            let input_box = model.get_box(input_box_id);
+            for child_q in input_box.quantifiers.iter() {
+                model.get_mut_quantifier(*child_q).parent_box = box_id;
+                outer_box.quantifiers.insert(*child_q);
+            }
+            if let Some(predicates) = input_box.get_predicates() {
+                for p in predicates.iter() {
+                    outer_box.add_predicate(p.clone());
+                }
+            }
+        }
+    }
+}

--- a/src/sql/src/query_model/rewrite_engine.rs
+++ b/src/sql/src/query_model/rewrite_engine.rs
@@ -9,7 +9,7 @@
 
 use crate::query_model::{
     BoxId, BoxScalarExpr, BoxType, ColumnReference, DistinctOperation, Model, QuantifierId,
-    QuantifierSet, QuantifierType,
+    QuantifierSet, QuantifierType, Select,
 };
 use itertools::Itertools;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -47,6 +47,7 @@ pub fn rewrite_model(model: &mut Model) {
         Box::new(ColumnRemoval::new()),
         Box::new(SelectMerge::new()),
         Box::new(ConstantLifting::new()),
+        Box::new(WindowingToSelect::new()),
     ];
     apply_rules_to_model(model, &mut rules);
     model.garbage_collect();
@@ -928,5 +929,41 @@ impl Rule for Windowing {
                 Ok(())
             },
         );
+    }
+}
+
+/// Any windowing box not projecting the result of any windowing function can be converted
+/// into a regular Select box.
+struct WindowingToSelect {}
+
+impl WindowingToSelect {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Rule for WindowingToSelect {
+    fn name(&self) -> &'static str {
+        "WindowingToSelect"
+    }
+
+    fn rule_type(&self) -> RuleType {
+        RuleType::PostOrder
+    }
+
+    fn condition(&mut self, model: &Model, box_id: BoxId) -> bool {
+        let b = model.get_box(box_id);
+        if let BoxType::Windowing = &b.box_type {
+            !b.columns
+                .iter()
+                .any(|c| matches!(c.expr, BoxScalarExpr::Windowing(..)))
+        } else {
+            false
+        }
+    }
+
+    fn action(&mut self, model: &mut Model, box_id: BoxId) {
+        let mut b = model.get_mut_box(box_id);
+        b.box_type = BoxType::Select(Select::new());
     }
 }

--- a/src/sql/src/query_model/rewrite_engine.rs
+++ b/src/sql/src/query_model/rewrite_engine.rs
@@ -27,6 +27,12 @@ pub enum RuleType {
 }
 
 /// Trait for rewrite rules
+/// 
+/// State stored in an object implementing this trait by [Rule::condition]
+/// can be carried over to the [Rule::action] call immediately after.
+/// 
+/// State should not be stored in an object to be carried over between different
+/// boxes or different calls to the same box. 
 pub trait Rule {
     fn name(&self) -> &'static str;
 

--- a/src/sql/src/query_model/rewrite_engine.rs
+++ b/src/sql/src/query_model/rewrite_engine.rs
@@ -112,6 +112,7 @@ pub fn apply_rules_to_model(model: &mut Model, rules: &mut Vec<RuleGenerator>) {
 fn apply_rule(rule: &mut dyn Rule, model: &mut Model, box_id: BoxId) {
     if rule.condition(model, box_id) {
         rule.action(model, box_id);
+        model.update_computed_properties(box_id);
         println!(
             "{}",
             crate::query_model::dot::DotGenerator::new()
@@ -1075,7 +1076,7 @@ impl Rule for ScalarToForeach {
                             &mut at_most_one_row_boxes,
                         );
                         if at_most_one_row_boxes[&input_box_id] {
-                        //if predicates.iter().any(|p| ) {
+                            //if predicates.iter().any(|p| ) {
                             Some(q_id)
                         //}
                         } else {

--- a/src/sql/src/query_model/rewrite_engine.rs
+++ b/src/sql/src/query_model/rewrite_engine.rs
@@ -499,7 +499,7 @@ impl Decorrelation {
                                 expr1: Box::new(left),
                                 expr2: Box::new(right),
                             };
-                            select_box.add_predicate(Box::new(cmp));
+                            select_box.add_predicate(cmp);
                         }
                     }
                     drop(select_box);
@@ -541,9 +541,7 @@ impl Decorrelation {
                         column_map
                             .iter()
                             .sorted_by_key(|(_, position)| **position)
-                            .map(|(col_ref, _)| {
-                                Box::new(BoxScalarExpr::ColumnReference(col_ref.clone()))
-                            }),
+                            .map(|(col_ref, _)| BoxScalarExpr::ColumnReference(col_ref.clone())),
                     );
                 }
 
@@ -814,7 +812,7 @@ impl Rule for Decorrelation {
                     expr1: Box::new(BoxScalarExpr::ColumnReference(col_ref.clone())),
                     expr2: Box::new(right),
                 };
-                model.get_mut_box(box_id).add_predicate(Box::new(cmp));
+                model.get_mut_box(box_id).add_predicate(cmp);
             }
 
             non_correlated_quantifires.insert(quantifier_id);

--- a/src/sql/src/query_model/rewrite_engine.rs
+++ b/src/sql/src/query_model/rewrite_engine.rs
@@ -8,9 +8,11 @@
 // by the Apache License, Version 2.0.
 
 use crate::query_model::{
-    BoxId, BoxScalarExpr, BoxType, DistinctOperation, Model, QuantifierSet, QuantifierType,
+    BoxId, BoxScalarExpr, BoxType, ColumnReference, DistinctOperation, Model, QuantifierId,
+    QuantifierSet, QuantifierType,
 };
-use std::collections::{BTreeSet, HashMap, HashSet};
+use itertools::Itertools;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 /// Rule type
 #[allow(dead_code)]
@@ -46,6 +48,12 @@ pub fn rewrite_model(model: &mut Model) {
     apply_rules_to_model(model, &mut rules);
 
     model.garbage_collect();
+
+    let mut decorrelation_rules: Vec<Box<dyn Rule>> = vec![Box::new(Decorrelation::new())];
+
+    apply_rules_to_model(model, &mut decorrelation_rules);
+
+    model.garbage_collect();
 }
 
 /// Transform the model by applying a list of rewrite rules.
@@ -71,6 +79,12 @@ pub fn apply_rules_to_model(model: &mut Model, rules: &mut Vec<Box<dyn Rule>>) {
 fn apply_rule(rule: &mut dyn Rule, model: &mut Model, box_id: BoxId) {
     if rule.condition(model, box_id) {
         rule.action(model, box_id);
+        println!(
+            "{}",
+            crate::query_model::dot::DotGenerator::new()
+                .generate(&model, rule.name())
+                .unwrap()
+        );
     }
 }
 
@@ -359,5 +373,421 @@ impl Rule for ColumnRemoval {
                 break;
             }
         }
+    }
+}
+
+/// Implements query decorrelation as a transformation rule.
+///
+/// A correlated box is a box where at least one of its quantifiers points
+/// to a sub-graph that references columns from other quantifiers in the
+/// correlated box.
+///
+/// Only join boxes (Select and OuterJoin boxes) can possibly correlated,
+/// but not full outer joins (OuterJoin box without a preserving quantifier).
+///
+/// This transformation decorrelates all correlated boxes in the model
+/// during a post order traversal, by apply the correlated quantifier to
+/// an outer relation producing all the distinct combinations of the columns
+/// the correlated quantifier depends on. The decorrelated box projects
+/// all the columns from the outer relation as a suffix. The decorrelated
+/// quantifier must be then joined with the columns from quantifiers in the
+/// current join it used to be correlated with.
+///
+/// Note: a quantifier cannot be correlated with itself, that is called
+/// recursion instead.
+struct Decorrelation {
+    /// The correlation information of the quantifiers in the current box
+    /// being evaluated.
+    correlation_info: BTreeMap<QuantifierId, HashSet<ColumnReference>>,
+}
+
+type CacheEntry = (
+    // Join box Id, usedd as the outer relation for decorrelation
+    BoxId,
+    // Column map
+    HashMap<ColumnReference, usize>,
+    // CTE cache
+    HashMap<BoxId, BoxId>,
+);
+
+impl Decorrelation {
+    fn new() -> Self {
+        Self {
+            correlation_info: BTreeMap::new(),
+        }
+    }
+
+    /// Returns a decorrelated version of the input relation, ie. that is not correlated with
+    /// any of the columns in the `column_map`.
+    ///
+    /// The resulting box projects the formerly correlated columns at the end of its projection.
+    fn decorrelate_internal(
+        &mut self,
+        model: &mut Model,
+        outer_relation: BoxId,
+        column_map: &HashMap<ColumnReference, usize>,
+        input_relation: BoxId,
+        decorrelated_boxes: &mut HashMap<BoxId, BoxId>,
+    ) -> BoxId {
+        let mut clone_box_and_decorrelate_inputs =
+            |model: &mut Model, box_id: BoxId| -> (BoxId, Vec<(QuantifierId, usize)>) {
+                let new_box = model.clone_box(box_id);
+                let input_quantifiers = model.get_box(new_box).quantifiers.clone();
+                let quantifiers_and_offsets = input_quantifiers
+                    .iter()
+                    .map(|q_id| {
+                        let input_box = model.get_quantifier(*q_id).input_box;
+                        let old_arity = model.get_box(input_box).columns.len();
+                        let decorrelated_box = self.decorrelate(
+                            model,
+                            outer_relation,
+                            column_map,
+                            input_box,
+                            decorrelated_boxes,
+                        );
+                        model.update_input_box(*q_id, decorrelated_box);
+                        (*q_id, old_arity)
+                    })
+                    .collect_vec();
+                (new_box, quantifiers_and_offsets)
+            };
+
+        let project_outer_columns =
+            |model: &Model,
+             box_id: BoxId,
+             input_quantifier: QuantifierId,
+             first_outer_column: usize| {
+                let mut the_box = model.get_mut_box(box_id);
+                for i in 0..column_map.len() {
+                    let col_ref = BoxScalarExpr::ColumnReference(ColumnReference {
+                        quantifier_id: input_quantifier,
+                        position: first_outer_column + i,
+                    });
+                    the_box.add_column(col_ref);
+                }
+            };
+
+        // TODO(asenac) avoid this cloning
+        let box_type = model.get_box(input_relation).box_type.clone();
+        let (new_box, input_quantifier_and_first_column) = match box_type {
+            BoxType::Select(_) => {
+                let (new_select_box, quantifiers_and_offsets) =
+                    clone_box_and_decorrelate_inputs(model, input_relation);
+
+                let outer_columns = column_map.len();
+                // join the input quantifiers by their outer columns
+                let mut it = quantifiers_and_offsets.iter();
+                if let Some((first_quantifier, first_offset)) = it.next() {
+                    let mut select_box = model.get_mut_box(new_select_box);
+                    for (other_quantifier, other_offset) in it {
+                        for i in 0..outer_columns {
+                            let left = BoxScalarExpr::ColumnReference(ColumnReference {
+                                quantifier_id: *first_quantifier,
+                                position: *first_offset + i,
+                            });
+                            let right = BoxScalarExpr::ColumnReference(ColumnReference {
+                                quantifier_id: *other_quantifier,
+                                position: *other_offset + i,
+                            });
+                            let cmp = BoxScalarExpr::CallBinary {
+                                // @todo BinaryFunc::ValueEq
+                                func: expr::BinaryFunc::Eq,
+                                expr1: Box::new(left),
+                                expr2: Box::new(right),
+                            };
+                            select_box.add_predicate(Box::new(cmp));
+                        }
+                    }
+                    drop(select_box);
+
+                    // Extend the projection of the select box to include the outer columns
+                    // at the end
+                    project_outer_columns(model, new_select_box, *first_quantifier, *first_offset);
+                }
+
+                (
+                    new_select_box,
+                    quantifiers_and_offsets.into_iter().find(|(q_id, _)| {
+                        model.get_quantifier(*q_id).quantifier_type == QuantifierType::Foreach
+                    }),
+                )
+            }
+            BoxType::Grouping(_) => {
+                let (new_grouping_box, quantifiers_and_offsets) =
+                    clone_box_and_decorrelate_inputs(model, input_relation);
+
+                if let Some((first_quantifier, first_offset)) =
+                    quantifiers_and_offsets.iter().next()
+                {
+                    // Extend the projection of the box to include the outer columns at the end
+                    project_outer_columns(
+                        model,
+                        new_grouping_box,
+                        *first_quantifier,
+                        *first_offset,
+                    );
+                }
+
+                // Add the outer columns to the grouping key. They will be rewritten later
+                // in terms of the input quantifier
+                if let BoxType::Grouping(grouping) =
+                    &mut model.get_mut_box(new_grouping_box).box_type
+                {
+                    grouping.key.extend(
+                        column_map
+                            .iter()
+                            .sorted_by_key(|(_, position)| **position)
+                            .map(|(col_ref, _)| {
+                                Box::new(BoxScalarExpr::ColumnReference(col_ref.clone()))
+                            }),
+                    );
+                }
+
+                (new_grouping_box, quantifiers_and_offsets.into_iter().next())
+            }
+            BoxType::Union | BoxType::Except | BoxType::Intersect => {
+                let (new_box, quantifiers_and_offsets) =
+                    clone_box_and_decorrelate_inputs(model, input_relation);
+
+                if let Some((first_quantifier, first_offset)) =
+                    quantifiers_and_offsets.iter().next()
+                {
+                    // Extend the projection of the box to include the outer columns at the end
+                    project_outer_columns(model, new_box, *first_quantifier, *first_offset);
+                }
+
+                (new_box, quantifiers_and_offsets.into_iter().next())
+            }
+            BoxType::Get(_) => {
+                let join_box = model.make_select_box();
+                model.make_quantifier(QuantifierType::Foreach, input_relation, join_box);
+                model.make_quantifier(QuantifierType::Foreach, outer_relation, join_box);
+                model.get_mut_box(join_box).add_all_input_columns(model);
+                (join_box, None)
+            }
+            _ => panic!("Cannot decorrelated this type of box"),
+        };
+
+        // Rewrite any expression within the box that references correlated columns.
+        // Replace them with column references to an input quantifier projecting the
+        // decorrelated columns at some offset.
+        if let Some((input_quantifier, first_column)) = input_quantifier_and_first_column {
+            let _ =
+                model
+                    .get_mut_box(new_box)
+                    .visit_expressions_mut(&mut |expr| -> Result<(), ()> {
+                        expr.visit_mut(&mut |expr| {
+                            if let BoxScalarExpr::ColumnReference(col_ref) = expr {
+                                if let Some(position) = column_map.get(col_ref) {
+                                    col_ref.quantifier_id = input_quantifier;
+                                    col_ref.position = first_column + *position;
+                                }
+                            }
+                        });
+                        Ok(())
+                    });
+
+            // Update correlated references among quantifiers in the current box
+            // TODO(asenac) this can be removed when full decorrelation is supported, since applying this
+            // rule in PostOrder means that the joins being decorrelated are not correlated internally.
+            let quantifier_map = model
+                .get_box(input_relation)
+                .quantifiers
+                .iter()
+                .zip(model.get_box(new_box).quantifiers.iter())
+                .map(|(old, new)| (*old, *new))
+                .collect::<HashMap<_, _>>();
+            if !quantifier_map.is_empty() {
+                let _ = model.visit_pre_boxes_in_subgraph_mut(
+                    &mut |mut b| -> Result<(), ()> {
+                        b.remap_column_references(&quantifier_map);
+                        Ok(())
+                    },
+                    new_box,
+                );
+            }
+        }
+
+        new_box
+    }
+
+    /// Returns the decorrelated version of `input_relation`. It avoids decorrelating
+    /// the same box several times (for example, when decorrelating CTEs) by using
+    /// `decorrelated_boxes` as a cache.
+    fn decorrelate(
+        &mut self,
+        model: &mut Model,
+        outer_relation: BoxId,
+        column_map: &HashMap<ColumnReference, usize>,
+        input_relation: BoxId,
+        decorrelated_boxes: &mut HashMap<BoxId, BoxId>,
+    ) -> BoxId {
+        if let Some(decorrelated_box) = decorrelated_boxes.get(&input_relation) {
+            *decorrelated_box
+        } else {
+            let decorrelated_box = self.decorrelate_internal(
+                model,
+                outer_relation,
+                column_map,
+                input_relation,
+                decorrelated_boxes,
+            );
+            decorrelated_boxes.insert(input_relation, decorrelated_box);
+            decorrelated_box
+        }
+    }
+
+    /// Builds a distinct sub-join with the quantifiers referenced in `dependencies` that
+    /// can be used as the outer relation for the decorrelation of a quantifier with these
+    /// dependencies.
+    ///
+    /// A cache is used to avoid creating the sub-graph when two or more quantifiers from
+    /// the same `join_box` have the same set of dependencies.
+    fn build_outer_relation_from_dependencies<'a>(
+        model: &mut Model,
+        _join_box: BoxId,
+        dependencies: HashSet<ColumnReference>,
+        cache: &'a mut HashMap<Vec<ColumnReference>, CacheEntry>,
+    ) -> &'a mut CacheEntry {
+        let dependencies = dependencies.into_iter().sorted().collect_vec();
+        cache.entry(dependencies.clone()).or_insert_with(move || {
+            // Build a join among the dependencies of the current quantifier
+            let outer_relation = model.make_select_box();
+            // Maps correlated column references with column positions in the outer_relation
+            let mut column_map = HashMap::new();
+            for (dependent_quantifier, col_refs) in &dependencies
+                .into_iter()
+                .sorted()
+                .group_by(|c| c.quantifier_id)
+            {
+                // Clone the quantifier in the new join box (outer_relation)
+                let (quantifier_type, input_box) = {
+                    let q = model.get_quantifier(dependent_quantifier);
+                    (q.quantifier_type.clone(), q.input_box)
+                };
+                let new_quantifier =
+                    model.make_quantifier(quantifier_type, input_box, outer_relation);
+
+                // Make `outer_relation` project all the columns from this quantifier
+                // the caller depends on
+                let mut outer_box = model.get_mut_box(outer_relation);
+                for col_ref in col_refs {
+                    let new_position = outer_box.columns.len();
+                    outer_box.add_column(BoxScalarExpr::ColumnReference(ColumnReference {
+                        quantifier_id: new_quantifier,
+                        position: col_ref.position,
+                    }));
+
+                    column_map.insert(col_ref.clone(), new_position);
+                }
+            }
+
+            model.get_mut_box(outer_relation).distinct = DistinctOperation::Enforce;
+
+            // @todo add all predicates from `join_box` that only reference
+            // dependent quantifiers
+
+            (outer_relation, column_map, HashMap::new())
+        })
+    }
+}
+
+impl Rule for Decorrelation {
+    fn name(&self) -> &'static str {
+        "Decorrelation"
+    }
+
+    fn rule_type(&self) -> RuleType {
+        RuleType::PostOrder
+    }
+
+    fn condition(&mut self, model: &Model, box_id: BoxId) -> bool {
+        let b = model.get_box(box_id);
+        if b.is_select() {
+            self.correlation_info = b.correlation_info(model);
+            // @todo For now we only decorrelate Foreach quantifiers. Add
+            // support for the remaining type of quantifiers
+            !self.correlation_info.is_empty()
+                && self.correlation_info.iter().all(|(q_id, _)| {
+                    model.get_quantifier(*q_id).quantifier_type == QuantifierType::Foreach
+                })
+        } else {
+            false
+        }
+    }
+
+    fn action(&mut self, model: &mut Model, box_id: BoxId) {
+        let mut non_correlated_quantifires = model
+            .get_box(box_id)
+            .quantifiers
+            .iter()
+            .filter(|q| !self.correlation_info.contains_key(q))
+            .cloned()
+            .collect::<QuantifierSet>();
+
+        // Cache with the `outer_relation` used for decorrelation.
+        let mut outer_relation_cache = HashMap::new();
+
+        let mut remaining_quantifiers = BTreeMap::new();
+        std::mem::swap(&mut self.correlation_info, &mut remaining_quantifiers);
+        let mut remaining_quantifiers = remaining_quantifiers.into_iter().collect_vec();
+
+        // Find the first correlated operand whose dependencies are satisfied
+        while let Some(position) = remaining_quantifiers.iter().position(|(_, dependencies)| {
+            dependencies
+                .iter()
+                .all(|c| non_correlated_quantifires.contains(&c.quantifier_id))
+        }) {
+            let (quantifier_id, dependencies) = remaining_quantifiers.remove(position);
+
+            // Build the outer relation joining the dependencies of the current quantifier
+            let (outer_relation, column_map, cte_cache) =
+                Self::build_outer_relation_from_dependencies(
+                    model,
+                    box_id,
+                    dependencies,
+                    &mut outer_relation_cache,
+                );
+
+            let correlated_box = model.get_quantifier(quantifier_id).input_box;
+            let old_arity = model.get_box(correlated_box).columns.len();
+            let decorrelated_box = self.decorrelate(
+                model,
+                *outer_relation,
+                column_map,
+                correlated_box,
+                cte_cache,
+            );
+            // Make the correlated quantifier point to the new correlated box, so it becomes
+            // a decorrelated quantifier.
+            model.update_input_box(quantifier_id, decorrelated_box);
+
+            // Join the decorrelated quantifier with the columns from the current select
+            // box it used to reference
+            for (col_ref, position) in column_map.iter().sorted_by_key(|(_, position)| **position) {
+                let right = BoxScalarExpr::ColumnReference(ColumnReference {
+                    quantifier_id,
+                    position: old_arity + position,
+                });
+                let cmp = BoxScalarExpr::CallBinary {
+                    // @todo BinaryFunc::ValueEq
+                    func: expr::BinaryFunc::Eq,
+                    expr1: Box::new(BoxScalarExpr::ColumnReference(col_ref.clone())),
+                    expr2: Box::new(right),
+                };
+                model.get_mut_box(box_id).add_predicate(Box::new(cmp));
+            }
+
+            non_correlated_quantifires.insert(quantifier_id);
+        }
+
+        // Remove any non-longer referenced objects from the model. This helps at catching bugs
+        // in the decorrelation logic.
+        model.garbage_collect();
+
+        // Simplify the decorrelated box by fusing any redundant `Select` boxes, for example,
+        // those added when the decorrelation logic is applied to a `Get` operator.
+        let mut rules: Vec<Box<dyn Rule>> = vec![Box::new(SelectMerge::new())];
+        deep_apply_rules(&mut rules, model, box_id, &mut HashSet::new());
     }
 }

--- a/src/sql/src/query_model/rewrite_engine.rs
+++ b/src/sql/src/query_model/rewrite_engine.rs
@@ -21,6 +21,9 @@ pub enum RuleType {
     TopBoxOnly,
     PreOrder,
     PostOrder,
+    /// Should be applied to all boxes, but does not have a preferred traversal
+    /// order.
+    AllBoxes,
 }
 
 /// Trait for rewrite rules
@@ -118,7 +121,7 @@ fn deep_apply_rules(
 
         for rule in rules
             .iter_mut()
-            .filter(|r| matches!(r.rule_type(), RuleType::PostOrder))
+            .filter(|r| matches!(r.rule_type(), RuleType::PostOrder | RuleType::AllBoxes))
         {
             apply_rule(&mut **rule, model, box_id);
         }
@@ -978,7 +981,7 @@ impl Rule for GroupingToDistinct {
     }
 
     fn rule_type(&self) -> RuleType {
-        RuleType::PostOrder
+        RuleType::AllBoxes
     }
 
     fn condition(&mut self, model: &Model, box_id: BoxId) -> bool {

--- a/src/sql/src/query_model/scalar_expr.rs
+++ b/src/sql/src/query_model/scalar_expr.rs
@@ -239,4 +239,13 @@ impl BoxScalarExpr {
             }
         })
     }
+
+    /// True if the expression doesn't reference any column from the given set of
+    /// quantifiers, even though it may contain other column references from other
+    /// contexts.
+    pub fn is_constant_within_context(&self, context: &QuantifierSet) -> bool {
+        let mut column_refs = HashSet::new();
+        self.collect_column_references_from_context(context, &mut column_refs);
+        column_refs.is_empty()
+    }
 }

--- a/src/sql/src/query_model/scalar_expr.rs
+++ b/src/sql/src/query_model/scalar_expr.rs
@@ -13,7 +13,7 @@ use std::fmt;
 use ore::str::separated;
 use repr::*;
 
-use crate::plan::expr::{BinaryFunc, NullaryFunc, UnaryFunc, VariadicFunc};
+use crate::plan::expr::{BinaryFunc, NullaryFunc, ScalarWindowFunc, UnaryFunc, VariadicFunc};
 use crate::query_model::{QuantifierId, QuantifierSet};
 use expr::AggregateFunc;
 
@@ -70,6 +70,7 @@ pub enum BoxScalarExpr {
         /// Should the aggregation be applied only to distinct results in each group.
         distinct: bool,
     },
+    Windowing(WindowExpr),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
@@ -82,6 +83,20 @@ pub struct ColumnReference {
 pub struct BaseColumn {
     pub position: usize,
     pub column_type: repr::ColumnType,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// Represents the invocation of a window function over a partition with an optional
+/// order.
+pub struct WindowExpr {
+    pub func: WindowExprType,
+    pub partition: Vec<BoxScalarExpr>,
+    pub order_by: Vec<BoxScalarExpr>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum WindowExprType {
+    Scalar(ScalarWindowFunc),
 }
 
 impl fmt::Display for BoxScalarExpr {
@@ -128,6 +143,31 @@ impl fmt::Display for BoxScalarExpr {
                     expr
                 )
             }
+            BoxScalarExpr::Windowing(expr) => {
+                match &expr.func {
+                    WindowExprType::Scalar(func) => write!(f, "{}()", func)?,
+                }
+                write!(f, " over (")?;
+                for (i, e) in expr.partition.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    e.fmt(f)?;
+                }
+                write!(f, ")")?;
+
+                if !expr.order_by.is_empty() {
+                    write!(f, " order by (")?;
+                    for (i, e) in expr.order_by.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        e.fmt(f)?;
+                    }
+                    write!(f, ")")?;
+                }
+                Ok(())
+            }
         }
     }
 }
@@ -157,6 +197,14 @@ impl BoxScalarExpr {
             }
             Aggregate { expr, .. } => {
                 f(expr);
+            }
+            Windowing(expr) => {
+                for expr in expr.partition.iter() {
+                    f(expr);
+                }
+                for expr in expr.order_by.iter() {
+                    f(expr);
+                }
             }
         }
     }
@@ -193,6 +241,14 @@ impl BoxScalarExpr {
             }
             Aggregate { expr, .. } => {
                 f(expr);
+            }
+            Windowing(expr) => {
+                for expr in expr.partition.iter_mut() {
+                    f(expr);
+                }
+                for expr in expr.order_by.iter_mut() {
+                    f(expr);
+                }
             }
         }
     }

--- a/src/sql/src/query_model/scalar_expr.rs
+++ b/src/sql/src/query_model/scalar_expr.rs
@@ -72,7 +72,7 @@ pub enum BoxScalarExpr {
     },
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 pub struct ColumnReference {
     pub quantifier_id: QuantifierId,
     pub position: usize,

--- a/src/sql/src/query_model/scalar_expr.rs
+++ b/src/sql/src/query_model/scalar_expr.rs
@@ -31,7 +31,7 @@ use expr::AggregateFunc;
 ///
 /// Scalar expressions only make sense within the context of a
 /// [`crate::query_model::QueryBox`], and hence, their name.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub enum BoxScalarExpr {
     /// A reference to a column from a quantifier that either lives in
     /// the same box as the expression or is a sibling quantifier of
@@ -79,13 +79,13 @@ pub struct ColumnReference {
     pub position: usize,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub struct BaseColumn {
     pub position: usize,
     pub column_type: repr::ColumnType,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Represents the invocation of a window function over a partition with an optional
 /// order.
 pub struct WindowExpr {
@@ -94,7 +94,7 @@ pub struct WindowExpr {
     pub order_by: Vec<BoxScalarExpr>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum WindowExprType {
     Scalar(ScalarWindowFunc),
 }

--- a/test/sqllogictest/cte_lowering.slt
+++ b/test/sqllogictest/cte_lowering.slt
@@ -1,0 +1,565 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test that correlated CTE are lowered properly
+
+mode cockroach
+
+statement ok
+CREATE TABLE x (a int)
+
+statement ok
+INSERT INTO x VALUES (1), (2), (3)
+
+statement ok
+CREATE TABLE y (a int)
+
+statement ok
+INSERT INTO y VALUES (2), (3), (4)
+
+# Check that CTEs aren't inlined during planning
+query T multiline
+EXPLAIN RAW PLAN FOR
+WITH t AS (SELECT * FROM y WHERE a < 3)
+  SELECT * FROM t NATURAL JOIN t a;
+----
+%0 = Let l0 =
+| Get materialize.public.y (u3)
+| Filter (#0 < 3)
+
+%1 =
+| InnerJoin %0 %0 on (true && (#0 = #1))
+| Project (#0)
+
+EOF
+
+# Check the body of a CTE is only lowered once
+query T multiline
+EXPLAIN DECORRELATED PLAN FOR
+WITH t AS (SELECT * FROM y WHERE a < 3)
+  SELECT * FROM t NATURAL JOIN t a;
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get materialize.public.y (u3)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+| Filter (#0 < 3)
+
+%3 = Let l2 =
+| Join %2 %2
+| | implementation = Unimplemented
+| Project (#0, #1)
+| Filter (true && (#0 = #1))
+
+%4 =
+| Get %3 (l2)
+| Project (#0)
+
+EOF
+
+# Correlated CTE inside a LATERAL join operand
+query T multiline
+EXPLAIN DECORRELATED PLAN FOR
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT * FROM a);
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get materialize.public.x (u1)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+
+%3 = Let l2 =
+| Get %2 (l1)
+| Distinct group=(#0)
+
+%4 =
+| Get materialize.public.y (u3)
+
+%5 = Let l3 =
+| Join %3 %4
+| | implementation = Unimplemented
+| Filter (#1 < #0)
+| Reduce group=(#0)
+| | agg max(#1)
+
+%6 =
+| Get %5 (l3)
+| Distinct group=(#0)
+| Negate
+
+%7 =
+| Get %3 (l2)
+| Distinct group=(#0)
+
+%8 =
+| Union %6 %7
+
+%9 =
+| Join %8 %3 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0)
+
+%10 =
+| Constant (null)
+
+%11 =
+| Join %9 %10
+| | implementation = Unimplemented
+
+%12 = Let l4 =
+| Union %5 %11
+
+%13 =
+| Get %12 (l4)
+
+%14 =
+| Join %2 %13 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0, #2)
+| Filter true
+
+EOF
+
+query II
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT * FROM a);
+----
+1  NULL
+2  NULL
+3  2
+
+# Correlated CTE used at different scope level: offset 0 and offset 1 (RHS of the join)
+# Note: the CTE is represented by %12 (l4)
+query T multiline
+EXPLAIN DECORRELATED PLAN FOR
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT * FROM a INNER JOIN a b ON a.m = b.m);
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get materialize.public.x (u1)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+
+%3 = Let l2 =
+| Get %2 (l1)
+| Distinct group=(#0)
+
+%4 =
+| Get materialize.public.y (u3)
+
+%5 = Let l3 =
+| Join %3 %4
+| | implementation = Unimplemented
+| Filter (#1 < #0)
+| Reduce group=(#0)
+| | agg max(#1)
+
+%6 =
+| Get %5 (l3)
+| Distinct group=(#0)
+| Negate
+
+%7 =
+| Get %3 (l2)
+| Distinct group=(#0)
+
+%8 =
+| Union %6 %7
+
+%9 =
+| Join %8 %3 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0)
+
+%10 =
+| Constant (null)
+
+%11 =
+| Join %9 %10
+| | implementation = Unimplemented
+
+%12 = Let l4 =
+| Union %5 %11
+
+%13 = Let l5 =
+| Join %12 %12 (= #0 #2)
+| | implementation = Unimplemented
+| Project (#0, #1, #3)
+| Filter (#1 = #2)
+
+%14 = Let l6 =
+| Get %13 (l5)
+| Project (#0, #1)
+| Distinct group=(#0, #1)
+
+%15 =
+| Get %13 (l5)
+
+%16 =
+| Join %2 %15 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0, #2, #3)
+| Filter true
+
+EOF
+
+query III
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT * FROM a INNER JOIN a b ON a.m = b.m);
+----
+3  2  2
+
+query III
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) as (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT * FROM a INNER JOIN a b ON true);
+----
+1  NULL  NULL
+2  NULL  NULL
+3  2  2
+
+# Correlated CTE used at different scope level: offset 0 and offset 3 (subquery in the
+# selection list of a derived relation in the RHS of the join)
+query T multiline
+EXPLAIN DECORRELATED PLAN FOR
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) as (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT * FROM a INNER JOIN (SELECT (SELECT m FROM a) FROM y) b ON true);
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get materialize.public.x (u1)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+
+%3 = Let l2 =
+| Get %2 (l1)
+| Distinct group=(#0)
+
+%4 =
+| Get materialize.public.y (u3)
+
+%5 = Let l3 =
+| Join %3 %4
+| | implementation = Unimplemented
+| Filter (#1 < #0)
+| Reduce group=(#0)
+| | agg max(#1)
+
+%6 =
+| Get %5 (l3)
+| Distinct group=(#0)
+| Negate
+
+%7 =
+| Get %3 (l2)
+| Distinct group=(#0)
+
+%8 =
+| Union %6 %7
+
+%9 =
+| Join %8 %3 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0)
+
+%10 =
+| Constant (null)
+
+%11 =
+| Join %9 %10
+| | implementation = Unimplemented
+
+%12 = Let l4 =
+| Union %5 %11
+
+%13 =
+| Get materialize.public.y (u3)
+
+%14 = Let l5 =
+| Join %3 %13
+| | implementation = Unimplemented
+
+%15 = Let l6 =
+| Get %14 (l5)
+| Distinct group=(#0, #1)
+
+%16 = Let l7 =
+| Get %15 (l6)
+| Distinct group=(#0)
+
+%17 = Let l8 =
+| Join %16 %12 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0, #2)
+
+%18 =
+| Get %17 (l8)
+| Reduce group=(#0)
+| | agg count(true)
+| Filter (#1 > 1)
+| Project (#0)
+| Map (err: more than one record produced in subquery)
+
+%19 = Let l9 =
+| Union %17 %18
+
+%20 =
+| Get %19 (l9)
+| Distinct group=(#0)
+| Negate
+
+%21 =
+| Get %16 (l7)
+| Distinct group=(#0)
+
+%22 =
+| Union %20 %21
+
+%23 =
+| Join %22 %16 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0)
+
+%24 =
+| Constant (null)
+
+%25 =
+| Join %23 %24
+| | implementation = Unimplemented
+
+%26 =
+| Union %19 %25
+
+%27 =
+| Join %15 %26 (= #0 #2)
+| | implementation = Unimplemented
+| Project (#0, #1, #3)
+
+%28 = Let l10 =
+| Join %14 %27 (= #0 #2) (= #1 #3)
+| | implementation = Unimplemented
+| Map #4
+| Project (#0, #1, #5)
+| Project (#0, #2)
+
+%29 = Let l11 =
+| Join %12 %28 (= #0 #2)
+| | implementation = Unimplemented
+| Project (#0, #1, #3)
+| Filter true
+
+%30 =
+| Get %29 (l11)
+
+%31 =
+| Join %2 %30 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0, #2, #3)
+| Filter true
+
+EOF
+
+query III
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT * FROM a INNER JOIN (SELECT (SELECT m FROM a) FROM y) b ON true);
+----
+1  NULL  NULL
+1  NULL  NULL
+1  NULL  NULL
+2  NULL  NULL
+2  NULL  NULL
+2  NULL  NULL
+3  2  2
+3  2  2
+3  2  2
+
+# Correlated CTE used from a correlated scope
+# Note: the CTE is represented by %12 (l4)
+query T multiline
+EXPLAIN DECORRELATED PLAN FOR
+SELECT *
+FROM x,
+     LATERAL(WITH a(m) AS (SELECT max(y.a) FROM y WHERE y.a < x.a)
+             SELECT * FROM y INNER JOIN LATERAL(SELECT y.a FROM x WHERE (SELECT m FROM a) > 0) ON true);
+----
+%0 = Let l0 =
+| Constant ()
+
+%1 =
+| Get materialize.public.x (u1)
+
+%2 = Let l1 =
+| Join %0 %1
+| | implementation = Unimplemented
+
+%3 = Let l2 =
+| Get %2 (l1)
+| Distinct group=(#0)
+
+%4 =
+| Get materialize.public.y (u3)
+
+%5 = Let l3 =
+| Join %3 %4
+| | implementation = Unimplemented
+| Filter (#1 < #0)
+| Reduce group=(#0)
+| | agg max(#1)
+
+%6 =
+| Get %5 (l3)
+| Distinct group=(#0)
+| Negate
+
+%7 =
+| Get %3 (l2)
+| Distinct group=(#0)
+
+%8 =
+| Union %6 %7
+
+%9 =
+| Join %8 %3 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0)
+
+%10 =
+| Constant (null)
+
+%11 =
+| Join %9 %10
+| | implementation = Unimplemented
+
+%12 = Let l4 =
+| Union %5 %11
+
+%13 =
+| Get materialize.public.y (u3)
+
+%14 = Let l5 =
+| Join %3 %13
+| | implementation = Unimplemented
+
+%15 = Let l6 =
+| Get %14 (l5)
+| Distinct group=(#1)
+
+%16 =
+| Get materialize.public.x (u1)
+
+%17 = Let l7 =
+| Join %15 %16
+| | implementation = Unimplemented
+| Filter true
+
+%18 = Let l8 =
+| Get %17 (l7)
+| Distinct group=(#0)
+
+%19 = Let l9 =
+| Join %18 %12 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0, #2)
+
+%20 =
+| Get %19 (l9)
+| Reduce group=(#0)
+| | agg count(true)
+| Filter (#1 > 1)
+| Project (#0)
+| Map (err: more than one record produced in subquery)
+
+%21 = Let l10 =
+| Union %19 %20
+
+%22 =
+| Get %21 (l10)
+| Distinct group=(#0)
+| Negate
+
+%23 =
+| Get %18 (l8)
+| Distinct group=(#0)
+
+%24 =
+| Union %22 %23
+
+%25 =
+| Join %24 %18 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0)
+
+%26 =
+| Constant (null)
+
+%27 =
+| Join %25 %26
+| | implementation = Unimplemented
+
+%28 =
+| Union %21 %27
+
+%29 = Let l11 =
+| Join %17 %28 (= #0 #2)
+| | implementation = Unimplemented
+| Project (#0, #1, #3)
+| Filter (#2 > 0)
+| Project (#0, #1)
+
+%30 =
+| Get %29 (l11)
+| Map #0
+| Project (#0..#2)
+| Project (#0, #2)
+
+%31 =
+| Join %14 %30 (= #1 #2)
+| | implementation = Unimplemented
+| Project (#0, #1, #3)
+| Filter true
+
+%32 =
+| Join %2 %31 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0, #2, #3)
+| Filter true
+
+EOF

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -110,8 +110,11 @@ WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
 SELECT row_number() OVER (PARTITION BY x ORDER BY x), x FROM t
 ORDER BY row_number, x
 ----
-%0 =
+%0 = Let l0 =
 | CallTable wrap2("a", 1, "b", 2, "c", 1)
+
+%1 =
+| Get %0 (l0)
 | Map row_number() over (#0) order by (#0)
 | Project (#2, #0)
 
@@ -132,11 +135,8 @@ ORDER BY row_number, x
 | Get %0 (l0)
 | FlatMap wrap2("a", 1, "b", 2, "c", 1)
 
-%2 = Let l2 =
+%2 =
 | Get %1 (l1)
-
-%3 =
-| Get %2 (l2)
 | Reduce group=(#0)
 | | agg row_number(record_create(list_create(record_create(#0, #1)), #0))
 | FlatMap unnest_list(#1)


### PR DESCRIPTION
### Motivation

Submitting my work so far on the QGM query rewrite practice so it can be checked for correctness. I have the `GroupByToDistinct` transform but not `ScalarToForeach`. Questions blocking my working on `ScalarToForeach` have been added to https://github.com/MaterializeInc/materialize/pull/9689.

### Tips for reviewer

The first commit is just changing `Vec<Box<BoxScalarExpr>>` to `Vec<BoxScalarExpr>`. 
The second commit is the `GroupByToDistinct` transform. I renamed it to `GroupingToDistinct` since the box type is `Grouping`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).
